### PR TITLE
Segtree impl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project( natprolib VERSION 2.0.0 )
 
 option( CMAKE_EXPORT_COMPILE_COMMANDS ON )
 
-set( CMAKE_CXX_STANDARD          17   )
+set( CMAKE_CXX_STANDARD          20   )
 set( CMAKE_CXX_STANDARD_REQUIRED True )
 
 add_compile_options( -Wall -Wextra -pedantic -Werror )

--- a/include/natprolib
+++ b/include/natprolib
@@ -12,3 +12,4 @@
 
 #include <range_queries/prefix_array>
 #include <range_queries/fenwick_tree>
+#include <range_queries/segment_tree>

--- a/include/range_queries/segment_tree
+++ b/include/range_queries/segment_tree
@@ -8,3 +8,656 @@
 #pragma once
 
 
+#include <algorithm>
+
+#include <util/mem.hpp>
+#include <util/util.hpp>
+#include <util/traits.hpp>
+#include <util/iterator.hpp>
+#include <util/split_buffer.hpp>
+
+#include <container/vector>
+
+
+namespace npl
+{
+
+
+template< typename T, typename Allocator >
+class _segment_tree_base;
+
+template< typename T, auto PB, typename Allocator >
+class segment_tree;
+
+
+struct segment_tree_iterator_tag : public random_access_iterator_tag {};
+
+template< typename T >
+struct is_segment_tree_iterator : public has_same_npl_iterator_category< iterator_traits< T >, segment_tree_iterator_tag > {};
+
+template< typename T >
+inline constexpr bool is_segment_tree_iterator_v = is_segment_tree_iterator< T >::value;
+
+
+template< typename T, typename Allocator >
+class _segment_tree_base
+        : protected _vector_base< T, Allocator >
+{
+public:
+        template< bool C, typename T_ = T, typename Allocator_ = Allocator >
+        class _segment_tree_iterator
+                : public iterator< T_, C, Allocator_ >
+        {
+                friend class _segment_tree_iterator< !C, T_, Allocator_ >;
+        public:
+                using                 _base = iterator< T_, C, Allocator_ >;
+                using npl_iterator_category = segment_tree_iterator_tag;
+        private:
+                explicit _segment_tree_iterator ( typename _base::pointer _ptr_ ) : _base( _ptr_ ) {}
+        };
+protected:
+        using          _base = _vector_base< T, Allocator >;
+        using       iterator = _segment_tree_iterator< false >;
+        using const_iterator = _segment_tree_iterator<  true >;
+        using allocator_type = typename _base::allocator_type;
+
+        _segment_tree_base (                                 ) noexcept( std::is_nothrow_default_constructible_v< allocator_type > ) : _base() {}
+        _segment_tree_base ( allocator_type const &  _alloc_ )          : _base (           _alloc_   ) {}
+        _segment_tree_base ( allocator_type       && _alloc_ ) noexcept : _base ( NPL_MOVE( _alloc_ ) ) {}
+};
+
+template< typename T, auto PB, typename Allocator = std::allocator< T > >
+class segment_tree
+        : _segment_tree_base< T, Allocator >
+{
+private:
+        using                   _self =  segment_tree;
+        using                   _base = _segment_tree_base< T, Allocator >;
+        using    _parent_builder_type = decltype( PB );
+        using _default_allocator_type = std::allocator< T >;
+
+        _parent_builder_type pb_{ PB };
+public:
+        using      value_type = T;
+        using  allocator_type = Allocator;
+        using   _alloc_traits = typename _base::  _alloc_traits;
+        using       reference = typename _base::      reference;
+        using const_reference = typename _base::const_reference;
+        using       size_type = typename _base::      size_type;
+        using difference_type = typename _base::difference_type;
+        using         pointer = typename _base::        pointer;
+        using   const_pointer = typename _base::  const_pointer;
+
+        using               iterator = typename _base::      iterator;
+        using         const_iterator = typename _base::const_iterator;
+        using       reverse_iterator = reverse_iter<       iterator >;
+        using const_reverse_iterator = reverse_iter< const_iterator >;
+
+        static_assert( ( std::is_same_v< typename allocator_type::value_type, value_type > ),
+                        "natprolib::segment_tree: allocator_type::value_type != self::value_type" );
+
+        static_assert( ( std::is_same_v< T, decltype( pb_( T(), T() ) ) > ),
+                        "natprolib::segment_tree: bad parent builder" );
+
+        segment_tree () noexcept( std::is_nothrow_default_constructible_v< allocator_type > ) {}
+
+        explicit segment_tree ( allocator_type const & _alloc_ ) noexcept : _base( _alloc_ ) {}
+
+        explicit segment_tree ( size_type const _count_                                 );
+        explicit segment_tree ( size_type const _count_, allocator_type const & _alloc_ );
+
+        segment_tree ( size_type const _count_, value_type const & _val_                                 );
+        segment_tree ( size_type const _count_, value_type const & _val_, allocator_type const & _alloc_ );
+
+        template< typename SegtreeIterator >
+        segment_tree ( SegtreeIterator _first_,
+                        typename std::enable_if_t
+                        <
+                                is_segment_tree_iterator_v< SegtreeIterator > &&
+                                std::is_constructible_v
+                                <
+                                        value_type,
+                                        typename std::iterator_traits< SegtreeIterator >::reference
+                                >,
+                                SegtreeIterator
+                        > _last_ );
+
+        template< typename SegtreeIterator >
+        segment_tree ( SegtreeIterator _first_, SegtreeIterator _last_, allocator_type const & _alloc_,
+                        typename std::enable_if_t
+                        <
+                                is_segment_tree_iterator_v< SegtreeIterator > &&
+                                std::is_constructible_v
+                                <
+                                        value_type,
+                                        typename std::iterator_traits< SegtreeIterator >::reference
+                                >
+                        > * = 0 );
+
+        template< typename InputIterator >
+        segment_tree ( InputIterator _first_,
+                        typename std::enable_if_t
+                        <
+                                 is_cpp17_input_iterator_v  < InputIterator > &&
+                                !is_cpp17_forward_iterator_v< InputIterator > &&
+                                !is_segment_tree_iterator_v < InputIterator > &&
+                                std::is_constructible_v
+                                <
+                                        value_type,
+                                        typename std::iterator_traits< InputIterator >::reference
+                                >,
+                                InputIterator
+                        > _last_ );
+
+        template< typename InputIterator >
+        segment_tree ( InputIterator _first_, InputIterator _last_, allocator_type const & _alloc_,
+                        typename std::enable_if_t
+                        <
+                                 is_cpp17_input_iterator_v  < InputIterator > &&
+                                !is_cpp17_forward_iterator_v< InputIterator > &&
+                                !is_segment_tree_iterator_v < InputIterator > &&
+                                std::is_constructible_v
+                                <
+                                        value_type,
+                                        typename std::iterator_traits< InputIterator >::reference
+                                >
+                        > * = 0 );
+
+        template< typename ForwardIterator >
+        segment_tree ( ForwardIterator _first_,
+                        typename std::enable_if_t
+                        <
+                                 is_cpp17_forward_iterator_v< ForwardIterator > &&
+                                !is_segment_tree_iterator_v < ForwardIterator > &&
+                                std::is_constructible_v
+                                <
+                                        value_type,
+                                        typename std::iterator_traits< ForwardIterator >::reference
+                                >,
+                                ForwardIterator
+                        > _last_ );
+
+        template< typename ForwardIterator >
+        segment_tree ( ForwardIterator _first_, ForwardIterator _last_, allocator_type const & _alloc_,
+                        typename std::enable_if_t
+                        <
+                                 is_cpp17_forward_iterator_v< ForwardIterator > &&
+                                !is_segment_tree_iterator_v < ForwardIterator > &&
+                                std::is_constructible_v
+                                <
+                                        value_type,
+                                        typename std::iterator_traits< ForwardIterator >::reference
+                                >
+                        > * = 0 );
+
+        ~segment_tree ()
+        {
+                _annotate_delete();
+        }
+
+        segment_tree ( segment_tree const & _other_                                              );
+        segment_tree ( segment_tree const & _other_, _identity< allocator_type > const & _alloc_ );
+
+        segment_tree & operator= ( segment_tree const & _other_ );
+
+        segment_tree ( segment_tree && _other_                                              );
+        segment_tree ( segment_tree && _other_, _identity< allocator_type > const & _alloc_ );
+
+        segment_tree & operator= ( segment_tree && _other_ )
+                noexcept( ( noexcept_move_assign_container_v< allocator_type, _alloc_traits > ) );
+
+        segment_tree ( std::initializer_list< value_type > _list_                                 );
+        segment_tree ( std::initializer_list< value_type > _list_, allocator_type const & _alloc_ );
+
+        segment_tree & operator= ( std::initializer_list< value_type > _list_ )
+        { assign( _list_.begin(), _list_.end() ); return *this; }
+
+        template< typename SegtreeIterator >
+        typename std::enable_if_t
+        <
+                is_segment_tree_iterator_v< SegtreeIterator > &&
+                std::is_constructible_v
+                <
+                        value_type,
+                        typename std::iterator_traits< SegtreeIterator >::reference
+                >,
+                void
+        >
+        assign ( SegtreeIterator _first_, SegtreeIterator _last_ );
+
+        template< typename InputIterator >
+        typename std::enable_if_t
+        <
+                 is_cpp17_input_iterator_v  < InputIterator > &&
+                !is_cpp17_forward_iterator_v< InputIterator > &&
+                !is_segment_tree_iterator_v < InputIterator > &&
+                std::is_constructible_v
+                <
+                        value_type,
+                        typename std::iterator_traits< InputIterator >::reference
+                >,
+                void
+        >
+        assign ( InputIterator _first_, InputIterator _last_ );
+
+#if 0
+        template< typename ForwardIterator >
+        typename std::enable_if_t
+        <
+                 is_cpp17_forward_iterator_v< ForwardIterator > &&
+                !is_segment_tree_iterator_v < ForwardIterator > &&
+                std::is_constructible_v
+                <
+                        value_type,
+                        typename std::iterator_traits< ForwardIterator >::reference
+                >,
+                void
+        >
+        assign ( ForwardIterator _first_, ForwardIterator _last_ );
+#endif
+
+        void assign ( std::initializer_list< value_type > _list_ )
+        { assign( _list_.begin(), _list_.end() ); }
+
+        allocator_type get_allocator () const noexcept
+        { return this->_alloc(); }
+
+              iterator begin ()       noexcept;
+              iterator   end ()       noexcept;
+        const_iterator begin () const noexcept;
+        const_iterator   end () const noexcept;
+
+        reverse_iterator rbegin () noexcept
+        { return reverse_iterator( end() ); }
+
+        reverse_iterator rend () noexcept
+        { return reverse_iterator( begin() ); }
+
+        const_reverse_iterator rbegin () const noexcept
+        { return const_reverse_iterator( end() ); }
+
+        const_reverse_iterator rend () const noexcept
+        { return const_reverse_iterator( begin() ); }
+
+        const_iterator cbegin () const noexcept
+        { return begin(); }
+
+        const_iterator cend () const noexcept
+        { return end(); }
+
+        const_reverse_iterator crbegin () const noexcept
+        { return rbegin(); }
+
+        const_reverse_iterator crend () const noexcept
+        { return rend(); }
+
+        NPL_NODISCARD size_type size () const noexcept
+        { return static_cast< size_type >( this->end_ - this->begin_ ) / 2; }  //  TODO: AYO PAY ATTENTION
+
+        NPL_NODISCARD size_type capacity () const noexcept
+        { return _base::capacity(); }
+
+        NPL_NODISCARD bool empty () const noexcept
+        { return this->begin_ == this->end_; }
+
+        size_type max_size () const noexcept;
+
+        void reserve ( size_type const _size_ );
+
+        void shrink_to_fit () noexcept;
+
+        NPL_ALWAYS_INLINE       reference operator[] ( size_type const _index_ )       noexcept;
+        NPL_ALWAYS_INLINE const_reference operator[] ( size_type const _index_ ) const noexcept;
+
+        bool   operator== ( segment_tree const & _rhs_ ) const noexcept;
+        bool   operator!= ( segment_tree const & _rhs_ ) const noexcept;
+        auto   operator+  ( segment_tree const & _rhs_ ) const         ;
+        auto & operator+= ( segment_tree const & _rhs_ )       noexcept;
+        auto   operator-  ( segment_tree const & _rhs_ ) const         ;
+        auto & operator-= ( segment_tree const & _rhs_ )       noexcept;
+
+        NPL_ALWAYS_INLINE       reference at ( size_type const _index_ )       noexcept;
+        NPL_ALWAYS_INLINE const_reference at ( size_type const _index_ ) const noexcept;
+
+        NPL_ALWAYS_INLINE value_type element_at ( size_type const _index_ ) const noexcept;
+
+        NPL_ALWAYS_INLINE NPL_FLATTEN value_type range (                                          ) const noexcept;
+        NPL_ALWAYS_INLINE             value_type range ( size_type const _x_, size_type const _y_ ) const noexcept;
+
+          //////////////////
+         // 2D overloads //
+        //////////////////
+
+        //////////////////
+
+          //////////////////
+         // 3D overloads //
+        //////////////////
+
+        //////////////////
+
+        reference front () noexcept
+        {
+                NPL_ASSERT( !empty(), "segment_tree::front: called on empty segment tree" );
+        }
+
+        const_reference front () const noexcept
+        {
+                NPL_ASSERT( !empty(), "segment_tree::front: called on empty segment tree" );
+        }
+
+        const_reference cfront () const noexcept
+        {
+                return front();
+        }
+
+        reference back () noexcept
+        {
+                NPL_ASSERT( !empty(), "segment_tree::back: called on empty segment tree" );
+        }
+
+        const_reference back () const noexcept
+        {
+                NPL_ASSERT( !empty(), "segment_tree::back: called on empty segment tree" );
+        }
+
+        const_reference cback () const noexcept
+        {
+                return back();
+        }
+
+        value_type * data () noexcept
+        { return mem::to_address( this->begin_ ); }
+
+        value_type const * data () const noexcept
+        { return mem::to_address( this->begin_ ); }
+
+        template< typename Arg >
+        void _emplace_back ( Arg&& _arg_ )
+        {
+                emplace_back( NPL_FWD( _arg_ ) );
+        }
+
+        void push_back ( const_reference _val_ );
+
+        template< typename... Args >
+        void push_back ( const_reference _val_, Args... _args_ )
+        {
+                push_back( _val_ );
+                push_back( _args_... );
+        }
+
+        void push_back ( value_type && _val_ );
+
+        template< typename... Args >
+        void push_back ( value_type && _val_, Args... _args_ )
+        {
+                push_back( _val_ );
+                push_back( _args_... );
+        }
+
+        template< typename... Args >
+        reference emplace_back ( Args&&... _args_ );
+
+        void pop_back ();
+
+        iterator insert ( const_iterator _position_, const_reference    _val_ );
+        iterator insert ( const_iterator _position_, value_type      && _val_ );
+
+        template< typename... Args >
+        iterator emplace ( const_iterator _position_, Args&&... _args_ );
+
+        iterator insert ( const_iterator _position_, size_type const _count_, const_reference _val_ );
+
+        template< typename SegtreeIterator >
+        typename std::enable_if_t
+        <
+                is_segment_tree_iterator_v< SegtreeIterator > &&
+                std::is_constructible_v
+                <
+                        value_type,
+                        typename std::iterator_traits< SegtreeIterator >::reference
+                >,
+                iterator
+        >
+        insert ( const_iterator _position_, SegtreeIterator _first_, SegtreeIterator _last_ );
+
+        template< typename InputIterator >
+        typename std::enable_if_t
+        <
+                 is_cpp17_input_iterator_v  < InputIterator > &&
+                !is_cpp17_forward_iterator_v< InputIterator > &&
+                !is_segment_tree_iterator_v < InputIterator > &&
+                std::is_constructible_v
+                <
+                        value_type,
+                        typename std::iterator_traits< InputIterator >::reference
+                >,
+                iterator
+        >
+        insert ( const_iterator _position_, InputIterator _first_, InputIterator _last_ );
+
+        template< typename ForwardIterator >
+        typename std::enable_if_t
+        <
+                is_cpp17_forward_iterator_v< ForwardIterator > &&
+                !is_segment_tree_iterator_v< ForwardIterator > &&
+                std::is_constructible_v
+                <
+                        value_type,
+                        typename std::iterator_traits< ForwardIterator >::reference
+                >,
+                iterator
+        >
+        insert ( const_iterator _position_, ForwardIterator _first_, ForwardIterator _last_ );
+
+        iterator insert ( const_iterator _position_, std::initializer_list< value_type > _list_ )
+        { return insert( _position_, _list_.begin(), _list_.end() ); }
+
+        iterator erase ( const_iterator _position_                        );
+        iterator erase ( const_iterator    _first_, const_iterator _last_ );
+
+        void resize ( size_type const _count_                        );
+        void resize ( size_type const _count_, const_reference _val_ );
+
+        void swap ( segment_tree & ) noexcept;
+
+        void clear () noexcept
+        {
+                size_type old_size = size();
+                _base::clear();
+                _annotate_shrink( old_size );
+                _invalidate_all_iterators();
+        }
+
+        bool _invariants () const;
+
+        bool _dereferenceable ( const_iterator const * _i_                     ) const;
+        bool _decrementable   ( const_iterator const * _i_                     ) const;
+        bool _addable         ( const_iterator const * _i_, std::ptrdiff_t _n_ ) const;
+        bool _subscriptable   ( const_iterator const * _i_, std::ptrdiff_t _n_ ) const;
+
+private:
+        void _invalidate_all_iterators  ();
+        void _invalidate_iterators_past ( pointer _new_last_ );
+
+        void _vallocate   ( size_type const _count_ );
+        void _vdeallocate (                         ) noexcept;
+
+        size_type _recommend ( size_type const _new_size_ ) const noexcept;
+
+        void _construct_at_end ( size_type const _count_                        );
+        void _construct_at_end ( size_type const _count_, const_reference _val_ );
+
+        template< typename SegtreeIterator >
+        typename std::enable_if_t
+        <
+                is_segment_tree_iterator_v< SegtreeIterator >,
+                void
+        >
+        _construct_at_end ( SegtreeIterator _first_, SegtreeIterator _last_, size_type const _count_ );
+
+        template< typename InputIterator >
+        typename std::enable_if_t
+        <
+                 is_cpp17_input_iterator_v  < InputIterator > &&
+                !is_cpp17_forward_iterator_v< InputIterator > &&
+                !is_segment_tree_iterator_v < InputIterator >,
+                void
+        >
+        _construct_at_end ( InputIterator _first_, InputIterator _last_, size_type const _count_ );
+
+        template< typename ForwardIterator >
+        typename std::enable_if_t
+        <
+                 is_cpp17_forward_iterator_v< ForwardIterator > &&
+                !is_segment_tree_iterator_v < ForwardIterator >,
+                void
+        >
+        _construct_at_end ( ForwardIterator _first_, ForwardIterator _last_, size_type const _count_ );
+
+        void _append ( size_type const _count_                        );
+        void _append ( size_type const _count_, const_reference _val_ );
+
+              iterator _make_iter ( pointer _ptr_ )       noexcept;
+        const_iterator _make_iter ( pointer _ptr_ ) const noexcept;
+
+        void    _swap_out_circular_buffer ( split_buffer< value_type, allocator_type & > & _buffer_                );
+        pointer _swap_out_circular_buffer ( split_buffer< value_type, allocator_type & > & _buffer_, pointer _ptr_ );
+
+        void _move_range ( pointer _from_s_, pointer _from_e_, pointer _to_ );
+
+        void _move_assign ( segment_tree & _other_, std::true_type  ) noexcept( std::is_nothrow_move_assignable_v< allocator_type > );
+        void _move_assign ( segment_tree & _other_, std::false_type ) noexcept( _alloc_traits::is_always_equal::value );
+
+        void _destruct_at_end ( pointer _new_last_ ) noexcept
+        {
+                _invalidate_iterators_past( _new_last_ );
+
+                size_type old_size = size();
+                _base::_destruct_at_end( _new_last_ );
+                _annotate_shrink( old_size );
+        }
+
+        template< typename U >
+        inline void _push_back_slow_path ( U && _val_ );
+
+        template< typename... Args >
+        inline void _emplace_back_slow_path ( Args&&... _args_ );
+
+#ifdef NPL_HAS_ASAN
+        void _annotate_contiguous_container ( void const * _beg_, void const * _end_,
+                                              void const * _old_mid_,
+                                              void const * _new_mid_ ) const
+        {
+                if( _beg_ && std::is_same_v< allocator_type, _default_allocator_type > )
+                {
+                        __sanitizer_annotate_contiguous_container( _beg_, _end_, _old_mid_, _new_mid_ );
+                }
+        }
+#else
+        void _annotate_contiguous_container ( void const *, void const *, void const *, void const * ) const noexcept {}
+#endif
+        void _annotate_new ( size_type _current_size_ ) const noexcept
+        {
+                _annotate_contiguous_container( data(), data() + capacity(),
+                                                data() + capacity(), data() + _current_size_ );
+        }
+
+        void _annotate_delete () const noexcept
+        {
+                _annotate_contiguous_container( data(), data() + capacity(),
+                                                data() + size(), data() + capacity() );
+        }
+
+        void _annotate_increase ( size_type _n_ ) const noexcept
+        {
+                _annotate_contiguous_container( data(), data() + capacity(),
+                                                data() + size(), data() + size() + _n_ );
+        }
+
+        void _annotate_shrink ( size_type _old_size_ ) const noexcept
+        {
+                _annotate_contiguous_container( data(), data() + capacity(),
+                                                data() + _old_size_, data() + size() );
+        }
+
+        struct _construct_transaction
+        {
+                explicit _construct_transaction ( segment_tree & _segtree_, size_type const _count_ )
+                        : segtree_ ( _segtree_ ),
+                          position_( _segtree_.end_ ),
+                          new_end_ ( _segtree_.end_ + _count_ )
+                {
+#ifdef NPL_HAS_ASAN
+                        segtree_._annotate_increase( _count_ );
+#endif
+                }
+
+                ~_construct_transaction ()
+                {
+                        segtree_.end_ = position_;
+#ifdef NPL_HAS_ASAN
+                        if( position_ != new_end_ )
+                        {
+                                segtree_._annotate_shrink( new_end_ - segtree_.begin_ );
+                        }
+#endif
+                }
+
+                segment_tree &      segtree_ ;
+                pointer             position_;
+                const_pointer const new_end_ ;
+
+        private:
+                _construct_transaction             ( _construct_transaction const & ) = delete;
+                _construct_transaction & operator= ( _construct_transaction const & ) = delete;
+        };
+
+        template< typename... Args >
+        void _construct_one_at_end ( Args... _args_ )
+        {
+                _construct_transaction tx( *this, 1 );
+
+                _alloc_traits::construct( this->_alloc(), mem::to_address( tx.position_ ), NPL_FWD( _args_ )... );
+                ++tx.position_;
+        }
+};
+
+
+} // namespace npl
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/include/range_queries/segment_tree
+++ b/include/range_queries/segment_tree
@@ -684,6 +684,26 @@ private:
         }
 };
 
+
+template< typename T,
+          auto     PB     = _default_parent_builder< T >,
+          typename Alloc  = std::allocator< T >,
+          typename        = std::enable_if< _is_allocator< Alloc >::value >,
+          typename Traits = std::allocator_traits< Alloc >
+        >
+segment_tree ( typename Traits::size_type const, T )
+        -> segment_tree< T, PB, Alloc >;
+
+template< typename T,
+          auto     PB     = _default_parent_builder< T >,
+          typename Alloc,
+          typename        = std::enable_if< _is_allocator< Alloc >::value >,
+          typename Traits = std::allocator_traits< Alloc >
+        >
+segment_tree ( typename Traits::size_type const, T, Alloc )
+        -> segment_tree< T, PB, Alloc >;
+
+
 template< typename T, auto PB, typename Allocator >
 void
 segment_tree< T, PB, Allocator >::_swap_out_circular_buffer ( split_buffer< value_type, allocator_type & > & _buffer_ )

--- a/include/range_queries/segment_tree
+++ b/include/range_queries/segment_tree
@@ -7,6 +7,9 @@
 
 #pragma once
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+
 
 #include <algorithm>
 
@@ -200,7 +203,7 @@ public:
 
         segment_tree & operator= ( segment_tree const & _other_ );
 
-        segment_tree ( segment_tree && _other_                                              );
+        segment_tree ( segment_tree && _other_                                              ) noexcept;
         segment_tree ( segment_tree && _other_, _identity< allocator_type > const & _alloc_ );
 
         segment_tree & operator= ( segment_tree && _other_ )
@@ -470,12 +473,12 @@ public:
                 _invalidate_all_iterators();
         }
 
-        bool _invariants () const;
+        bool _invariants () const noexcept;
 
-        bool _dereferenceable ( const_iterator const * _i_                     ) const;
-        bool _decrementable   ( const_iterator const * _i_                     ) const;
-        bool _addable         ( const_iterator const * _i_, std::ptrdiff_t _n_ ) const;
-        bool _subscriptable   ( const_iterator const * _i_, std::ptrdiff_t _n_ ) const;
+        bool _dereferenceable ( const_iterator const * _i_                     ) const noexcept;
+        bool _decrementable   ( const_iterator const * _i_                     ) const noexcept;
+        bool _addable         ( const_iterator const * _i_, std::ptrdiff_t _n_ ) const noexcept;
+        bool _subscriptable   ( const_iterator const * _i_, std::ptrdiff_t _n_ ) const noexcept;
 
 private:
         void _invalidate_all_iterators  ();
@@ -484,7 +487,12 @@ private:
         void _vallocate   ( size_type const _count_ );
         void _vdeallocate (                         ) noexcept;
 
+        size_type _msb           ( size_type       _val_ ) const noexcept;
+        size_type _round_to_pow2 ( size_type const _size_ ) const noexcept;
+
         size_type _recommend ( size_type const _new_size_ ) const noexcept;
+
+        void _rebuild_tree () noexcept;
 
         void _construct_at_end ( size_type const _count_                        );
         void _construct_at_end ( size_type const _count_, const_reference _val_ );
@@ -519,8 +527,8 @@ private:
         void _append ( size_type const _count_                        );
         void _append ( size_type const _count_, const_reference _val_ );
 
-              iterator _make_iter ( pointer _ptr_ )       noexcept;
-        const_iterator _make_iter ( pointer _ptr_ ) const noexcept;
+              iterator _make_iter (       pointer _ptr_ )       noexcept;
+        const_iterator _make_iter ( const_pointer _ptr_ ) const noexcept;
 
         void    _swap_out_circular_buffer ( split_buffer< value_type, allocator_type & > & _buffer_                );
         pointer _swap_out_circular_buffer ( split_buffer< value_type, allocator_type & > & _buffer_, pointer _ptr_ );
@@ -624,40 +632,744 @@ private:
         }
 };
 
+template< typename T, auto PB, typename Allocator >
+void
+segment_tree< T, PB, Allocator >::_swap_out_circular_buffer ( split_buffer< value_type, allocator_type & > & _buffer_ )
+{
+        _annotate_delete();
+
+        mem::_construct_backward_with_exception_guarantees( this->_alloc(), this->begin_, this->end_, _buffer_.begin_ );
+
+        std::swap( this->begin_    , _buffer_.begin_     );
+        std::swap( this->end_      , _buffer_.end_       );
+        std::swap( this->_end_cap(), _buffer_._end_cap() );
+
+        _buffer_.first_ = _buffer_.begin_;
+        _annotate_new( size() );
+        _invalidate_all_iterators();
+}
+
+template< typename T, auto PB, typename Allocator >
+typename segment_tree< T, PB, Allocator >::pointer
+segment_tree< T, PB, Allocator >::_swap_out_circular_buffer ( split_buffer< value_type, allocator_type & > & _buffer_, pointer _ptr_ )
+{
+        _annotate_delete();
+
+        pointer ret = _buffer_.begin_;
+
+        mem::_construct_backward_with_exception_guarantees( this->_alloc(), this->begin_,      _ptr_, _buffer_.begin_ );
+        mem::_construct_forward_with_exception_guarantees ( this->_alloc(),        _ptr_, this->end_, _buffer_.end_   );
+
+        std::swap( this->begin_    , _buffer_.begin_     );
+        std::swap( this->end_      , _buffer_.end_       );
+        std::swap( this->_end_cap(), _buffer_._end_cap() );
+
+        _buffer_.first_ = _buffer_.begin_;
+        _annotate_new( size() );
+        _invalidate_all_iterators();
+
+        return ret;
+}
+
+template< typename T, auto PB, typename Allocator >
+void
+segment_tree< T, PB, Allocator >::_vallocate ( size_type const _count_ )
+{
+        // default
+}
+
+template< typename T, auto PB, typename Allocator >
+void
+segment_tree< T, PB, Allocator >::_vdeallocate () noexcept
+{
+        // default
+}
+
+template< typename T, auto PB, typename Allocator >
+typename segment_tree< T, PB, Allocator >::size_type
+segment_tree< T, PB, Allocator >::max_size () const noexcept
+{
+        return std::min< size_type >( _alloc_traits::max_size( this->_alloc() ), std::numeric_limits< difference_type >::max() );
+}
+
+template< typename T, auto PB, typename Allocator >
+inline
+typename segment_tree< T, PB, Allocator >::size_type
+segment_tree< T, PB, Allocator >::_msb ( size_type _size_ ) const noexcept
+{
+        _size_ |= ( _size_ >>  1 );
+        _size_ |= ( _size_ >>  2 );
+        _size_ |= ( _size_ >>  4 );
+        _size_ |= ( _size_ >>  8 );
+        _size_ |= ( _size_ >> 16 );
+
+        if constexpr( sizeof( size_type ) == 8 )
+        {
+                _size_ |= ( _size_ >> 32 );
+        }
+
+        return ( _size_ & ~( _size_ >> 1 ) );
+}
+
+template< typename T, auto PB, typename Allocator >
+inline
+typename segment_tree< T, PB, Allocator >::size_type
+segment_tree< T, PB, Allocator >::_round_to_pow2 ( size_type const _size_ ) const noexcept
+{
+        auto msb = _msb( _size_ );
+
+        return  _size_ == msb ?
+                _size_ :
+                ( msb << 1 );
+}
+
+template< typename T, auto PB, typename Allocator >
+inline
+typename segment_tree< T, PB, Allocator >::size_type
+segment_tree< T, PB, Allocator >::_recommend ( size_type const _new_size_ ) const noexcept
+{
+        // has to be called on every reallocation
+        // returns closest power of two
+}
+
+template< typename T, auto PB, typename Allocator >
+void
+segment_tree< T, PB, Allocator >::_rebuild_tree () noexcept
+{
+        // one possible implementation
+        {
+                for( auto i = ( size() / 2 ) - 1; i > 0; --i )
+                {
+                        this->begin_[ i ] = pb_( this->begin_[ 2 * i ], this->begin[ 2 * i + 1 ] );
+                }
+        }
+}
+
+template< typename T, auto PB, typename Allocator >
+void
+segment_tree< T, PB, Allocator >::_construct_at_end ( size_type const _count_ )
+{
+        // default
+}
+
+template< typename T, auto PB, typename Allocator >
+void
+segment_tree< T, PB, Allocator >::_construct_at_end ( size_type const _count_, const_reference _val_ )
+{
+        // default
+}
+
+template< typename T, auto PB, typename Allocator >
+template< typename SegtreeIterator >
+typename std::enable_if_t
+<
+        is_segment_tree_iterator_v< SegtreeIterator >,
+        void
+>
+segment_tree< T, PB, Allocator >::_construct_at_end ( SegtreeIterator _first_, SegtreeIterator _last_, size_type const _count_ )
+{
+        // default
+}
+
+template< typename T, auto PB, typename Allocator >
+template< typename InputIterator >
+typename std::enable_if_t
+<
+         is_cpp17_input_iterator_v  < InputIterator > &&
+        !is_cpp17_forward_iterator_v< InputIterator > &&
+        !is_segment_tree_iterator_v < InputIterator >,
+        void
+>
+segment_tree< T, PB, Allocator >::_construct_at_end ( InputIterator _first_, InputIterator _last_, size_type const _count_ )
+{
+        // default
+}
+
+template< typename T, auto PB, typename Allocator >
+template< typename ForwardIterator >
+typename std::enable_if_t
+<
+         is_cpp17_forward_iterator_v< ForwardIterator > &&
+        !is_segment_tree_iterator_v < ForwardIterator >,
+        void
+>
+segment_tree< T, PB, Allocator >::_construct_at_end ( ForwardIterator _first_, ForwardIterator _last_, size_type const _count_ )
+{
+        // default
+}
+
+template< typename T, auto PB, typename Allocator >
+void
+segment_tree< T, PB, Allocator >::_append ( size_type const _count_ )
+{
+        // default
+}
+
+template< typename T, auto PB, typename Allocator >
+void
+segment_tree< T, PB, Allocator >::_append ( size_type const _count_, const_reference _val_ )
+{
+        // default
+}
+
+template< typename T, auto PB, typename Allocator >
+segment_tree< T, PB, Allocator >::segment_tree ( size_type const _count_ )
+{
+        // find power of two and allocate double
+}
+
+template< typename T, auto PB, typename Allocator >
+segment_tree< T, PB, Allocator >::segment_tree ( size_type const _count_, allocator_type const & _alloc_ )
+        : _base( _alloc_ )
+{
+        // find power of two and allocate double
+}
+
+template< typename T, auto PB, typename Allocator >
+segment_tree< T, PB, Allocator >::segment_tree ( size_type const _count_, value_type const & _val_ )
+{
+        // power of two
+        // alloc double
+        // fill
+        // reconstruct tree
+}
+
+template< typename T, auto PB, typename Allocator >
+segment_tree< T, PB, Allocator >::segment_tree ( size_type const _count_, value_type const & _val_, allocator_type const & _alloc_ )
+        : _base( _alloc_ )
+{
+        // same as above
+}
+
+template< typename T, auto PB, typename Allocator >
+template< typename SegtreeIterator >
+segment_tree< T, PB, Allocator >::segment_tree ( SegtreeIterator _first_,
+                typename std::enable_if_t
+                <
+                        is_segment_tree_iterator_v< SegtreeIterator > &&
+                        std::is_constructible_v
+                        <
+                                value_type,
+                                typename std::iterator_traits< SegtreeIterator >::reference
+                        >,
+                        SegtreeIterator
+                > _last_ )
+{
+        // default
+}
+
+template< typename T, auto PB, typename Allocator >
+template< typename SegtreeIterator >
+segment_tree< T, PB, Allocator >::segment_tree ( SegtreeIterator _first_, SegtreeIterator _last_, allocator_type const & _alloc_,
+                typename std::enable_if_t
+                <
+                        is_segment_tree_iterator_v< SegtreeIterator > &&
+                        std::is_constructible_v
+                        <
+                                value_type,
+                                typename std::iterator_traits< SegtreeIterator >::reference
+                        >
+                > * )
+        : _base( _alloc_ )
+{
+        // same as above
+}
+
+template< typename T, auto PB, typename Allocator >
+template< typename InputIterator >
+segment_tree< T, PB, Allocator >::segment_tree ( InputIterator _first_,
+                typename std::enable_if_t
+                <
+                         is_cpp17_input_iterator_v  < InputIterator > &&
+                        !is_cpp17_forward_iterator_v< InputIterator > &&
+                        !is_segment_tree_iterator_v < InputIterator > &&
+                        std::is_constructible_v
+                        <
+                                value_type,
+                                typename std::iterator_traits< InputIterator >::reference
+                        >,
+                        InputIterator
+                > _last_ )
+{
+        // default
+}
+
+template< typename T, auto PB, typename Allocator >
+template< typename InputIterator >
+segment_tree< T, PB, Allocator >::segment_tree ( InputIterator _first_, InputIterator _last_, allocator_type const & _alloc_,
+                typename std::enable_if_t
+                <
+                         is_cpp17_input_iterator_v  < InputIterator > &&
+                        !is_cpp17_forward_iterator_v< InputIterator > &&
+                        !is_segment_tree_iterator_v < InputIterator > &&
+                        std::is_constructible_v
+                        <
+                                value_type,
+                                typename std::iterator_traits< InputIterator >::reference
+                        >
+                > * )
+        : _base( _alloc_ )
+{
+        // same as above
+}
+
+template< typename T, auto PB, typename Allocator >
+template< typename ForwardIterator >
+segment_tree< T, PB, Allocator >::segment_tree ( ForwardIterator _first_,
+                typename std::enable_if_t
+                <
+                         is_cpp17_forward_iterator_v< ForwardIterator > &&
+                        !is_segment_tree_iterator_v < ForwardIterator > &&
+                        std::is_constructible_v
+                        <
+                                value_type,
+                                typename std::iterator_traits< ForwardIterator >::reference
+                        >,
+                        ForwardIterator
+                > _last_ )
+{
+        // default
+}
+
+template< typename T, auto PB, typename Allocator >
+template< typename ForwardIterator >
+segment_tree< T, PB, Allocator >::segment_tree ( ForwardIterator _first_, ForwardIterator _last_, allocator_type const & _alloc_,
+                typename std::enable_if_t
+                <
+                         is_cpp17_forward_iterator_v< ForwardIterator > &&
+                        !is_segment_tree_iterator_v < ForwardIterator > &&
+                        std::is_constructible_v
+                        <
+                                value_type,
+                                typename std::iterator_traits< ForwardIterator >::reference
+                        >
+                > * )
+        : _base( _alloc_ )
+{
+        // same as above
+}
+
+template< typename T, auto PB, typename Allocator >
+segment_tree< T, PB, Allocator >::segment_tree ( segment_tree const & _other_ )
+        : _base( _alloc_traits::select_on_container_copy_construction( _other_._alloc() ) )
+{
+        // default
+}
+
+template< typename T, auto PB, typename Allocator >
+segment_tree< T, PB, Allocator >::segment_tree ( segment_tree const & _other_, _identity< allocator_type > const & _alloc_ )
+        : _base( _alloc_ )
+{
+        // same as above
+}
+
+template< typename T, auto PB, typename Allocator >
+inline
+segment_tree< T, PB, Allocator >::segment_tree ( segment_tree && _other_ ) noexcept
+        : _base( NPL_MOVE( _other_._alloc() ) )
+{
+        // default
+}
+
+template< typename T, auto PB, typename Allocator >
+inline
+segment_tree< T, PB, Allocator >::segment_tree ( segment_tree && _other_, _identity< allocator_type > const & _alloc_ )
+        : _base( _alloc_ )
+{
+        // same as above
+}
+
+template< typename T, auto PB, typename Allocator >
+inline
+segment_tree< T, PB, Allocator >::segment_tree ( std::initializer_list< value_type > _list_ )
+{
+        // power of two
+        // alloc double
+        // fill
+        // construct tree
+}
+
+template< typename T, auto PB, typename Allocator >
+inline
+segment_tree< T, PB, Allocator >::segment_tree ( std::initializer_list< value_type > _list_, allocator_type const & _alloc_ )
+        : _base( _alloc_ )
+{
+
+}
+
+template< typename T, auto PB, typename Allocator >
+inline
+segment_tree< T, PB, Allocator > &
+segment_tree< T, PB, Allocator >::operator= ( segment_tree && _other_ )
+        noexcept( ( noexcept_move_assign_container_v< Allocator, _alloc_traits > ) )
+{
+        // default
+}
+
+template< typename T, auto PB, typename Allocator >
+void
+segment_tree< T, PB, Allocator >::_move_assign ( segment_tree & _other_, std::false_type )
+        noexcept( _alloc_traits::is_always_equal::value )
+{
+        // default
+}
+
+template< typename T, auto PB, typename Allocator >
+void
+segment_tree< T, PB, Allocator >::_move_assign ( segment_tree & _other_, std::true_type )
+        noexcept( std::is_nothrow_move_assignable_v< allocator_type > )
+{
+        // default
+}
+
+template< typename T, auto PB, typename Allocator >
+inline
+segment_tree< T, PB, Allocator > &
+segment_tree< T, PB, Allocator >::operator= ( segment_tree const & _other_ )
+{
+        // default
+}
+
+template< typename T, auto PB, typename Allocator >
+template< typename SegtreeIterator >
+typename std::enable_if_t
+<
+        is_segment_tree_iterator_v< SegtreeIterator > &&
+        std::is_constructible_v
+        <
+                T,
+                typename std::iterator_traits< SegtreeIterator >::reference
+        >,
+        void
+>
+segment_tree< T, PB, Allocator >::assign ( SegtreeIterator _first_, SegtreeIterator _last_ )
+{
+        // default
+}
+
+template< typename T, auto PB, typename Allocator >
+template< typename InputIterator >
+typename std::enable_if_t
+<
+         is_cpp17_input_iterator_v  < InputIterator > &&
+        !is_cpp17_forward_iterator_v< InputIterator > &&
+        !is_segment_tree_iterator_v < InputIterator > &&
+        std::is_constructible_v
+        <
+                T,
+                typename std::iterator_traits< InputIterator >::reference
+        >,
+        void
+>
+segment_tree< T, PB, Allocator >::assign ( InputIterator _first_, InputIterator _last_ )
+{
+        // emplace back
+}
+
+#if 0
+template< typename T, auto PB, typename Allocator >
+template< typename ForwardIterator >
+typename std::enable_if_t
+<
+         is_cpp17_forward_iterator_v< ForwardIterator > &&
+        !is_segment_tree_iterator_v < ForwardIterator > &&
+        std::is_constructible_v
+        <
+                T,
+                typename std::iterator_traits< ForwardIterator >::reference
+        >,
+        void
+>
+segment_tree< T, PB, Allocator >::assign ( ForwardIterator _first_, ForwardIterator _last_ )
+{
+
+}
+#endif
+
+template< typename T, auto PB, typename Allocator >
+inline
+typename segment_tree< T, PB, Allocator >::iterator
+segment_tree< T, PB, Allocator >::_make_iter ( pointer _ptr_ ) noexcept
+{
+        return iterator( _ptr_ );
+}
+
+template< typename T, auto PB, typename Allocator >
+inline
+typename segment_tree< T, PB, Allocator >::const_iterator
+segment_tree< T, PB, Allocator >::_make_iter ( const_pointer _ptr_ ) const noexcept
+{
+        return const_iterator( _ptr_ );
+}
+
+template< typename T, auto PB, typename Allocator >
+inline
+typename segment_tree< T, PB, Allocator >::iterator
+segment_tree< T, PB, Allocator >::begin () noexcept
+{
+        return _make_iter( this->begin_ );
+}
+
+template< typename T, auto PB, typename Allocator >
+inline
+typename segment_tree< T, PB, Allocator >::const_iterator
+segment_tree< T, PB, Allocator >::begin () const noexcept
+{
+        return _make_iter( this->begin_ );
+}
+
+template< typename T, auto PB, typename Allocator >
+inline
+typename segment_tree< T, PB, Allocator >::iterator
+segment_tree< T, PB, Allocator >::end () noexcept
+{
+        return _make_iter( this->end_ );
+}
+
+template< typename T, auto PB, typename Allocator >
+inline
+typename segment_tree< T, PB, Allocator >::const_iterator
+segment_tree< T, PB, Allocator >::end () const noexcept
+{
+        return _make_iter( this->end_ );
+}
+
+template< typename T, auto PB, typename Allocator >
+NPL_ALWAYS_INLINE
+typename segment_tree< T, PB, Allocator >::reference
+segment_tree< T, PB, Allocator >::operator[] ( size_type const _index_ ) noexcept
+{
+        // return being + size / 2 + index
+}
+
+template< typename T, auto PB, typename Allocator >
+NPL_ALWAYS_INLINE
+typename segment_tree< T, PB, Allocator >::const_reference
+segment_tree< T, PB, Allocator >::operator[] ( size_type const _index_ ) const noexcept
+{
+        // same as above
+}
+
+template< typename T, auto PB, typename Allocator >
+inline
+bool
+segment_tree< T, PB, Allocator >::operator== ( segment_tree const & _other_ ) const noexcept
+{
+
+}
+
+template< typename T, auto PB, typename Allocator >
+inline
+bool
+segment_tree< T, PB, Allocator >::operator!= ( segment_tree const & _other_ ) const noexcept
+{
+        return !operator==( _other_ );
+}
+
+template< typename T, auto PB, typename Allocator >
+inline
+auto &
+segment_tree< T, PB, Allocator >::operator+= ( segment_tree const & _other_ ) noexcept
+{
+
+}
+
+template< typename T, auto PB, typename Allocator >
+inline
+auto
+segment_tree< T, PB, Allocator >::operator+ ( segment_tree const & _other_ ) const
+{
+
+}
+
+template< typename T, auto PB, typename Allocator >
+inline
+auto &
+segment_tree< T, PB, Allocator >::operator-= ( segment_tree const & _other_ ) noexcept
+{
+
+}
+
+template< typename T, auto PB, typename Allocator >
+inline
+auto
+segment_tree< T, PB, Allocator >::operator- ( segment_tree const & _other_ ) const
+{
+
+}
+
+template< typename T, auto PB, typename Allocator >
+NPL_ALWAYS_INLINE
+typename segment_tree< T, PB, Allocator >::reference
+segment_tree< T, PB, Allocator >::at ( size_type const _index_ ) noexcept
+{
+        // same as operator[]
+}
+
+template< typename T, auto PB, typename Allocator >
+NPL_ALWAYS_INLINE
+typename segment_tree< T, PB, Allocator >::const_reference
+segment_tree< T, PB, Allocator >::at ( size_type const _index_ ) const noexcept
+{
+        // same as above
+}
+
+template< typename T, auto PB, typename Allocator >
+NPL_ALWAYS_INLINE
+typename segment_tree< T, PB, Allocator >::value_type
+segment_tree< T, PB, Allocator >::element_at ( size_type const _index_ ) const noexcept
+{
+
+}
+
+template< typename T, auto PB, typename Allocator >
+NPL_ALWAYS_INLINE NPL_FLATTEN
+typename segment_tree< T, PB, Allocator >::value_type
+segment_tree< T, PB, Allocator >::range () const noexcept
+{
+
+}
+
+template< typename T, auto PB, typename Allocator >
+NPL_ALWAYS_INLINE
+typename segment_tree< T, PB, Allocator >::value_type
+segment_tree< T, PB, Allocator >::range ( size_type const _x_, size_type const _y_ ) const noexcept
+{
+
+}
+
+template< typename T, auto PB, typename Allocator >
+void
+segment_tree< T, PB, Allocator >::reserve ( size_type const _size_ )
+{
+
+}
+
+template< typename T, auto PB, typename Allocator >
+void
+segment_tree< T, PB, Allocator >::shrink_to_fit () noexcept
+{
+
+}
+
+template< typename T, auto PB, typename Allocator >
+template< typename U >
+void
+segment_tree< T, PB, Allocator >::_push_back_slow_path ( U && _val_ )
+{
+
+}
+
+template< typename T, auto PB, typename Allocator >
+inline
+void
+segment_tree< T, PB, Allocator >::push_back ( const_reference _val_ )
+{
+
+}
+
+template< typename T, auto PB, typename Allocator >
+inline
+void
+segment_tree< T, PB, Allocator >::push_back ( value_type && _val_ )
+{
+
+}
+
+template< typename T, auto PB, typename Allocator >
+template< typename... Args >
+void
+segment_tree< T, PB, Allocator >::_emplace_back_slow_path ( Args&&... _args_ )
+{
+
+}
+
+template< typename T, auto PB, typename Allocator >
+template< typename... Args >
+inline
+typename segment_tree< T, PB, Allocator >::reference
+segment_tree< T, PB, Allocator >::emplace_back ( Args&&... _args_ )
+{
+
+}
+
+template< typename T, auto PB, typename Allocator >
+inline
+void
+segment_tree< T, PB, Allocator >::pop_back ()
+{
+
+}
+
+template< typename T, auto PB, typename Allocator >
+void
+segment_tree< T, PB, Allocator >::resize ( size_type const _size_ )
+{
+
+}
+
+template< typename T, auto PB, typename Allocator >
+void
+segment_tree< T, PB, Allocator >::resize ( size_type const _size_, const_reference _val_ )
+{
+
+}
+
+template< typename T, auto PB, typename Allocator >
+void
+segment_tree< T, PB, Allocator >::swap ( segment_tree & _other_ ) noexcept
+{
+
+}
+
+template< typename T, auto PB, typename Allocator >
+inline
+void
+segment_tree< T, PB, Allocator >::_invalidate_all_iterators ()
+{}
+
+template< typename T, auto PB, typename Allocator >
+inline
+void
+segment_tree< T, PB, Allocator >::_invalidate_iterators_past ( [[ maybe_unused ]] pointer _new_last_ )
+{}
+
+template< typename T, auto PB, typename Allocator >
+bool
+segment_tree< T, PB, Allocator >::_invariants () const noexcept
+{
+
+}
+
+template< typename T, auto PB, typename Allocator >
+bool
+segment_tree< T, PB, Allocator >::_dereferenceable ( const_iterator const * _i_ ) const noexcept
+{
+        return this->begin_ <= _i_->base() && _i_->base() < this->end_;
+}
+
+template< typename T, auto PB, typename Allocator >
+bool
+segment_tree< T, PB, Allocator >::_decrementable ( const_iterator const * _i_ ) const noexcept
+{
+        return this->begin_ < _i_->base() && _i_->base() <= this->end_;
+}
+
+template< typename T, auto PB, typename Allocator >
+bool
+segment_tree< T, PB, Allocator >::_addable ( const_iterator const * _i_, std::ptrdiff_t _n_ ) const noexcept
+{
+        const_pointer p = _i_->base() + _n_;
+        return this->begin_ <= p && p <= this->end_;
+}
+
+template< typename T, auto PB, typename Allocator >
+bool
+segment_tree< T, PB, Allocator >::_subscriptable ( const_iterator const * _i_, std::ptrdiff_t _n_ ) const noexcept
+{
+        const_pointer p = _i_->base() + _n_;
+        return this->begin_ <= p && p < this->end_;
+}
+
 
 } // namespace npl
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/include/range_queries/segment_tree
+++ b/include/range_queries/segment_tree
@@ -46,19 +46,20 @@ template< typename T, typename Allocator >
 class _segment_tree_base
         : protected _vector_base< T, Allocator >
 {
-public:
+protected:
         template< bool C, typename T_ = T, typename Allocator_ = Allocator >
         class _segment_tree_iterator
                 : public iterator< T_, C, Allocator_ >
         {
                 friend class _segment_tree_iterator< !C, T_, Allocator_ >;
+                friend class _segment_tree_base    <     T , Allocator  >;
         public:
                 using                 _base = iterator< T_, C, Allocator_ >;
                 using npl_iterator_category = segment_tree_iterator_tag;
-        private:
+
                 explicit _segment_tree_iterator ( typename _base::pointer _ptr_ ) : _base( _ptr_ ) {}
         };
-protected:
+
         using          _base = _vector_base< T, Allocator >;
         using       iterator = _segment_tree_iterator< false >;
         using const_iterator = _segment_tree_iterator<  true >;
@@ -69,17 +70,27 @@ protected:
         _segment_tree_base ( allocator_type       && _alloc_ ) noexcept : _base ( NPL_MOVE( _alloc_ ) ) {}
 };
 
-template< typename T, auto PB, typename Allocator = std::allocator< T > >
+template< typename T >
+auto _default_parent_builder
+{
+        []( [[ maybe_unused ]] T const & lhs, [[ maybe_unused ]] T const & rhs )
+        {
+                return T();
+        }
+};
+
+template< typename T, auto PB = _default_parent_builder< T >, typename Allocator = std::allocator< T > >
 class segment_tree
         : _segment_tree_base< T, Allocator >
 {
 private:
-        using                   _self =  segment_tree;
-        using                   _base = _segment_tree_base< T, Allocator >;
-        using    _parent_builder_type = decltype( PB );
-        using _default_allocator_type = std::allocator< T >;
+        using                        _self =  segment_tree;
+        using                        _base = _segment_tree_base< T, Allocator >;
+        using         _parent_builder_type = decltype( PB );
+        using      _default_allocator_type = std::allocator< T >;
+        using _default_parent_builder_type = decltype( _default_parent_builder< T > );
 
-        _parent_builder_type pb_{ PB };
+        _parent_builder_type parent_builder_{ PB };
 public:
         using      value_type = T;
         using  allocator_type = Allocator;
@@ -99,7 +110,7 @@ public:
         static_assert( ( std::is_same_v< typename allocator_type::value_type, value_type > ),
                         "natprolib::segment_tree: allocator_type::value_type != self::value_type" );
 
-        static_assert( ( std::is_same_v< T, decltype( pb_( T(), T() ) ) > ),
+        static_assert( ( std::is_same_v< T, decltype( parent_builder_( T(), T() ) ) > ),
                         "natprolib::segment_tree: bad parent builder" );
 
         segment_tree () noexcept( std::is_nothrow_default_constructible_v< allocator_type > ) {}
@@ -137,6 +148,7 @@ public:
                                 >
                         > * = 0 );
 
+#if 0
         template< typename InputIterator >
         segment_tree ( InputIterator _first_,
                         typename std::enable_if_t
@@ -165,6 +177,7 @@ public:
                                         typename std::iterator_traits< InputIterator >::reference
                                 >
                         > * = 0 );
+#endif
 
         template< typename ForwardIterator >
         segment_tree ( ForwardIterator _first_,
@@ -243,7 +256,6 @@ public:
         >
         assign ( InputIterator _first_, InputIterator _last_ );
 
-#if 0
         template< typename ForwardIterator >
         typename std::enable_if_t
         <
@@ -257,13 +269,30 @@ public:
                 void
         >
         assign ( ForwardIterator _first_, ForwardIterator _last_ );
-#endif
 
         void assign ( std::initializer_list< value_type > _list_ )
         { assign( _list_.begin(), _list_.end() ); }
 
         allocator_type get_allocator () const noexcept
         { return this->_alloc(); }
+
+        iterator real_begin () noexcept
+        {
+                return iterator( this->begin_ );
+        }
+        const_iterator real_begin () const noexcept
+        {
+                return const_iterator( this->begin_ );
+        }
+
+        iterator real_end () noexcept
+        {
+                return iterator( this->end_ );
+        }
+        const_iterator real_end () const noexcept
+        {
+                return const_iterator( this->end_ );
+        }
 
               iterator begin ()       noexcept;
               iterator   end ()       noexcept;
@@ -294,11 +323,14 @@ public:
         const_reverse_iterator crend () const noexcept
         { return rend(); }
 
-        NPL_NODISCARD size_type size () const noexcept
-        { return static_cast< size_type >( this->end_ - this->begin_ ) / 2; }  //  TODO: AYO PAY ATTENTION
+        NPL_NODISCARD size_type real_size () const noexcept
+        { return static_cast< size_type >( this->end_ - this->begin_ ); }
 
         NPL_NODISCARD size_type capacity () const noexcept
         { return _base::capacity(); }
+
+        NPL_NODISCARD size_type size () const noexcept
+        { return capacity() / 2; }
 
         NPL_NODISCARD bool empty () const noexcept
         { return this->begin_ == this->end_; }
@@ -324,8 +356,8 @@ public:
 
         NPL_ALWAYS_INLINE value_type element_at ( size_type const _index_ ) const noexcept;
 
-        NPL_ALWAYS_INLINE NPL_FLATTEN value_type range (                                          ) const noexcept;
-        NPL_ALWAYS_INLINE             value_type range ( size_type const _x_, size_type const _y_ ) const noexcept;
+        NPL_ALWAYS_INLINE NPL_FLATTEN value_type range (                              ) const noexcept;
+        NPL_ALWAYS_INLINE             value_type range ( size_type _x_, size_type _y_ ) const noexcept;
 
           //////////////////
          // 2D overloads //
@@ -342,11 +374,15 @@ public:
         reference front () noexcept
         {
                 NPL_ASSERT( !empty(), "segment_tree::front: called on empty segment tree" );
+
+                return this->begin_[ capacity() / 2 ];
         }
 
         const_reference front () const noexcept
         {
                 NPL_ASSERT( !empty(), "segment_tree::front: called on empty segment tree" );
+
+                return this->begin_[ capacity() / 2 ];
         }
 
         const_reference cfront () const noexcept
@@ -357,11 +393,15 @@ public:
         reference back () noexcept
         {
                 NPL_ASSERT( !empty(), "segment_tree::back: called on empty segment tree" );
+
+                return this->begin_[ capacity() - 1 ];
         }
 
         const_reference back () const noexcept
         {
                 NPL_ASSERT( !empty(), "segment_tree::back: called on empty segment tree" );
+
+                return this->begin_[ capacity() - 1 ];
         }
 
         const_reference cback () const noexcept
@@ -467,7 +507,7 @@ public:
 
         void clear () noexcept
         {
-                size_type old_size = size();
+                size_type old_size = real_size();
                 _base::clear();
                 _annotate_shrink( old_size );
                 _invalidate_all_iterators();
@@ -493,6 +533,18 @@ private:
         size_type _recommend ( size_type const _new_size_ ) const noexcept;
 
         void _rebuild_tree () noexcept;
+
+        void _update ( size_type const _position_, const_reference _val_ );
+        void _update ( const_iterator  _position_, const_reference _val_ );
+
+        void _update ( size_type const _position_, value_type && _val_ ) noexcept;
+        void _update ( const_iterator  _position_, value_type && _val_ ) noexcept;
+
+        template< typename... Args >
+        void _update ( size_type const _position_, Args... _args_ ) noexcept;
+
+        template< typename... Args >
+        void _update ( const_iterator _position_, Args... _args_ ) noexcept;
 
         void _construct_at_end ( size_type const _count_                        );
         void _construct_at_end ( size_type const _count_, const_reference _val_ );
@@ -542,7 +594,7 @@ private:
         {
                 _invalidate_iterators_past( _new_last_ );
 
-                size_type old_size = size();
+                size_type old_size = real_size();
                 _base::_destruct_at_end( _new_last_ );
                 _annotate_shrink( old_size );
         }
@@ -575,19 +627,19 @@ private:
         void _annotate_delete () const noexcept
         {
                 _annotate_contiguous_container( data(), data() + capacity(),
-                                                data() + size(), data() + capacity() );
+                                                data() + real_size(), data() + capacity() );
         }
 
         void _annotate_increase ( size_type _n_ ) const noexcept
         {
                 _annotate_contiguous_container( data(), data() + capacity(),
-                                                data() + size(), data() + size() + _n_ );
+                                                data() + real_size(), data() + real_size() + _n_ );
         }
 
         void _annotate_shrink ( size_type _old_size_ ) const noexcept
         {
                 _annotate_contiguous_container( data(), data() + capacity(),
-                                                data() + _old_size_, data() + size() );
+                                                data() + _old_size_, data() + real_size() );
         }
 
         struct _construct_transaction
@@ -645,7 +697,7 @@ segment_tree< T, PB, Allocator >::_swap_out_circular_buffer ( split_buffer< valu
         std::swap( this->_end_cap(), _buffer_._end_cap() );
 
         _buffer_.first_ = _buffer_.begin_;
-        _annotate_new( size() );
+        _annotate_new( real_size() );
         _invalidate_all_iterators();
 }
 
@@ -665,7 +717,7 @@ segment_tree< T, PB, Allocator >::_swap_out_circular_buffer ( split_buffer< valu
         std::swap( this->_end_cap(), _buffer_._end_cap() );
 
         _buffer_.first_ = _buffer_.begin_;
-        _annotate_new( size() );
+        _annotate_new( real_size() );
         _invalidate_all_iterators();
 
         return ret;
@@ -675,14 +727,24 @@ template< typename T, auto PB, typename Allocator >
 void
 segment_tree< T, PB, Allocator >::_vallocate ( size_type const _count_ )
 {
-        // default
+        NPL_ASSERT( _count_ <= max_size(), "segment_tree::_vallocate: size > max_size" );
+
+        this->begin_ = this->end_ = _alloc_traits::allocate( this->_alloc(), _count_ );
+        this->end_cap_ = this->begin_ + _count_;
+
+        _annotate_new( 0 );
 }
 
 template< typename T, auto PB, typename Allocator >
 void
 segment_tree< T, PB, Allocator >::_vdeallocate () noexcept
 {
-        // default
+        if( this->begin_ != nullptr )
+        {
+                clear();
+                _alloc_traits::deallocate( this->_alloc(), this->begin_, capacity() );
+                this->begin_ = this->end_ = this->end_cap_ = nullptr;
+        }
 }
 
 template< typename T, auto PB, typename Allocator >
@@ -728,8 +790,18 @@ inline
 typename segment_tree< T, PB, Allocator >::size_type
 segment_tree< T, PB, Allocator >::_recommend ( size_type const _new_size_ ) const noexcept
 {
-        // has to be called on every reallocation
-        // returns closest power of two
+        size_type const ms = max_size();
+
+        NPL_ASSERT( _new_size_ < ms, "segment_tree::_recommend: new size > max size" );
+
+        size_type const cap = capacity();
+
+        if( cap >= ms / 2 )
+        {
+                return ms;
+        }
+
+        return std::max< size_type >( 2 * cap, 2 * ( _round_to_pow2( _new_size_ ) ) );
 }
 
 template< typename T, auto PB, typename Allocator >
@@ -738,25 +810,83 @@ segment_tree< T, PB, Allocator >::_rebuild_tree () noexcept
 {
         // one possible implementation
         {
-                for( auto i = ( size() / 2 ) - 1; i > 0; --i )
+                for( auto i = ( capacity() / 2 ) - 1; i > 0; --i )
                 {
-                        this->begin_[ i ] = pb_( this->begin_[ 2 * i ], this->begin[ 2 * i + 1 ] );
+                        this->begin_[ i ] = parent_builder_( this->begin_[ 2 * i ], this->begin_[ 2 * i + 1 ] );
                 }
         }
 }
 
 template< typename T, auto PB, typename Allocator >
 void
+segment_tree< T, PB, Allocator >::_update ( size_type const _position_, const_reference _val_ )
+{
+
+}
+
+template< typename T, auto PB, typename Allocator >
+void
+segment_tree< T, PB, Allocator >::_update ( const_iterator _position_, const_reference _val_ )
+{
+
+}
+
+template< typename T, auto PB, typename Allocator >
+void
+segment_tree< T, PB, Allocator >::_update ( size_type const _position_, value_type && _val_ ) noexcept
+{
+
+}
+
+template< typename T, auto PB, typename Allocator >
+void
+segment_tree< T, PB, Allocator >::_update ( const_iterator _position_, value_type && _val_ ) noexcept
+{
+
+}
+
+template< typename T, auto PB, typename Allocator >
+template< typename... Args >
+void
+segment_tree< T, PB, Allocator >::_update ( size_type const _position_, Args... _args_ ) noexcept
+{
+
+}
+
+template< typename T, auto PB, typename Allocator >
+template< typename... Args >
+void
+segment_tree< T, PB, Allocator >::_update ( const_iterator _position_, Args... _args_ ) noexcept
+{
+
+}
+
+template< typename T, auto PB, typename Allocator >
+void
 segment_tree< T, PB, Allocator >::_construct_at_end ( size_type const _count_ )
 {
-        // default
+        _construct_transaction tx( *this, _count_ );
+
+        const_pointer new_end = tx.new_end_;
+
+        for( pointer pos = tx.position_; pos != new_end; ++pos, tx.position_ = pos )
+        {
+                _alloc_traits::construct( this->_alloc(), mem::to_address( pos ) );
+        }
 }
 
 template< typename T, auto PB, typename Allocator >
 void
 segment_tree< T, PB, Allocator >::_construct_at_end ( size_type const _count_, const_reference _val_ )
 {
-        // default
+        _construct_transaction tx( *this, _count_ );
+
+        const_pointer new_end = tx.new_end_;
+
+        for( pointer pos = tx.position_; pos != new_end; ++pos, tx.position_ = pos )
+        {
+                _alloc_traits::construct( this->_alloc(), mem::to_address( pos ), _val_ );
+        }
 }
 
 template< typename T, auto PB, typename Allocator >
@@ -768,7 +898,9 @@ typename std::enable_if_t
 >
 segment_tree< T, PB, Allocator >::_construct_at_end ( SegtreeIterator _first_, SegtreeIterator _last_, size_type const _count_ )
 {
-        // default
+        _construct_transaction tx( *this, _count_ );
+
+        mem::_construct_range_forward( this->_alloc(), _first_, _last_, tx.position_ );
 }
 
 template< typename T, auto PB, typename Allocator >
@@ -780,9 +912,15 @@ typename std::enable_if_t
         !is_segment_tree_iterator_v < InputIterator >,
         void
 >
-segment_tree< T, PB, Allocator >::_construct_at_end ( InputIterator _first_, InputIterator _last_, size_type const _count_ )
+segment_tree< T, PB, Allocator >::_construct_at_end ( InputIterator _first_, InputIterator _last_, size_type const _count_ )  //  TODO: temp impl
 {
-        // default
+        _construct_transaction tx( *this, _count_ );
+        const_pointer new_end = tx.new_end_;
+
+        for( pointer pos = tx.position_; pos != new_end && _first_ != _last_; ++pos, tx.position_ = pos )
+        {
+                _alloc_traits::construct( this->_alloc(), mem::to_address( pos ), *_first_++ );
+        }
 }
 
 template< typename T, auto PB, typename Allocator >
@@ -793,9 +931,15 @@ typename std::enable_if_t
         !is_segment_tree_iterator_v < ForwardIterator >,
         void
 >
-segment_tree< T, PB, Allocator >::_construct_at_end ( ForwardIterator _first_, ForwardIterator _last_, size_type const _count_ )
+segment_tree< T, PB, Allocator >::_construct_at_end ( ForwardIterator _first_, ForwardIterator _last_, size_type const _count_ )  //  TODO: temp impl
 {
-        // default
+        _construct_transaction tx( *this, _count_ );
+        const_pointer new_end = tx.new_end_;
+
+        for( pointer pos = tx.position_; pos != new_end && _first_ != _last_; ++pos, tx.position_ = pos )
+        {
+                _alloc_traits::construct( this->_alloc(), mem::to_address( pos ), *_first_++ );
+        }
 }
 
 template< typename T, auto PB, typename Allocator >
@@ -815,30 +959,61 @@ segment_tree< T, PB, Allocator >::_append ( size_type const _count_, const_refer
 template< typename T, auto PB, typename Allocator >
 segment_tree< T, PB, Allocator >::segment_tree ( size_type const _count_ )
 {
-        // find power of two and allocate double
+        if( _count_ > 0 )
+        {
+                auto new_size = _round_to_pow2( _count_ );
+                auto new_cap  = 2 * new_size;
+
+                _vallocate( new_cap );
+                _construct_at_end( new_size );
+        }
 }
 
 template< typename T, auto PB, typename Allocator >
 segment_tree< T, PB, Allocator >::segment_tree ( size_type const _count_, allocator_type const & _alloc_ )
         : _base( _alloc_ )
 {
-        // find power of two and allocate double
+        if( _count_ > 0 )
+        {
+                auto new_size = _round_to_pow2( _count_ );
+                auto new_cap  = 2 * new_size;
+
+                _vallocate( new_cap );
+                _construct_at_end( new_size );
+        }
 }
 
 template< typename T, auto PB, typename Allocator >
 segment_tree< T, PB, Allocator >::segment_tree ( size_type const _count_, value_type const & _val_ )
 {
-        // power of two
-        // alloc double
-        // fill
-        // reconstruct tree
+        if( _count_ > 0 )
+        {
+                auto new_size = _round_to_pow2( _count_ );
+                auto new_cap  = 2 * new_size;
+
+                _vallocate( new_cap );
+                _construct_at_end( new_size );
+                _construct_at_end( _count_, _val_ );
+                _construct_at_end( new_size - _count_ );
+                _rebuild_tree();
+        }
 }
 
 template< typename T, auto PB, typename Allocator >
 segment_tree< T, PB, Allocator >::segment_tree ( size_type const _count_, value_type const & _val_, allocator_type const & _alloc_ )
         : _base( _alloc_ )
 {
-        // same as above
+        if( _count_ > 0 )
+        {
+                auto new_size = _round_to_pow2( _count_ );
+                auto new_cap  = 2 * new_size;
+
+                _vallocate( new_cap );
+                _construct_at_end( new_size );
+                _construct_at_end( _count_, _val_ );
+                _construct_at_end( new_size - _count_ );
+                _rebuild_tree();
+        }
 }
 
 template< typename T, auto PB, typename Allocator >
@@ -855,7 +1030,15 @@ segment_tree< T, PB, Allocator >::segment_tree ( SegtreeIterator _first_,
                         SegtreeIterator
                 > _last_ )
 {
-        // default
+        size_type count    = std::distance( _first_, _last_ );
+        size_type new_size = _round_to_pow2( count );
+        size_type new_cap  = 2 * new_size;
+
+        _vallocate( new_cap );
+        _construct_at_end( new_size );
+        _construct_at_end( _first_, _last_, count );
+        _construct_at_end( new_size - count );
+        _rebuild_tree();
 }
 
 template< typename T, auto PB, typename Allocator >
@@ -872,9 +1055,18 @@ segment_tree< T, PB, Allocator >::segment_tree ( SegtreeIterator _first_, Segtre
                 > * )
         : _base( _alloc_ )
 {
-        // same as above
+        size_type count    = std::distance( _first_, _last_ );
+        size_type new_size = _round_to_pow2( count );
+        size_type new_cap  = 2 * new_size;
+
+        _vallocate( new_cap );
+        _construct_at_end( new_size );
+        _construct_at_end( _first_, _last_, count );
+        _construct_at_end( new_size - count );
+        _rebuild_tree();
 }
 
+#if 0
 template< typename T, auto PB, typename Allocator >
 template< typename InputIterator >
 segment_tree< T, PB, Allocator >::segment_tree ( InputIterator _first_,
@@ -891,7 +1083,10 @@ segment_tree< T, PB, Allocator >::segment_tree ( InputIterator _first_,
                         InputIterator
                 > _last_ )
 {
-        // default
+        for( ; _first_ != _last_; ++_first_ )
+        {
+                _emplace_back( *_first_ );
+        }
 }
 
 template< typename T, auto PB, typename Allocator >
@@ -910,8 +1105,12 @@ segment_tree< T, PB, Allocator >::segment_tree ( InputIterator _first_, InputIte
                 > * )
         : _base( _alloc_ )
 {
-        // same as above
+        for( ; _first_ != _last_; ++_first_ )
+        {
+                _emplace_back( *_first_ );
+        }
 }
+#endif
 
 template< typename T, auto PB, typename Allocator >
 template< typename ForwardIterator >
@@ -928,7 +1127,15 @@ segment_tree< T, PB, Allocator >::segment_tree ( ForwardIterator _first_,
                         ForwardIterator
                 > _last_ )
 {
-        // default
+        size_type count    = std::distance( _first_, _last_ );
+        size_type new_size = _round_to_pow2( count );
+        size_type new_cap  = 2 * new_size;
+
+        _vallocate( new_cap );
+        _construct_at_end( new_size );
+        _construct_at_end( _first_, _last_, count );
+        _construct_at_end( new_size - count );
+        _rebuild_tree();
 }
 
 template< typename T, auto PB, typename Allocator >
@@ -946,21 +1153,49 @@ segment_tree< T, PB, Allocator >::segment_tree ( ForwardIterator _first_, Forwar
                 > * )
         : _base( _alloc_ )
 {
-        // same as above
+        size_type count    = std::distance( _first_, _last_ );
+        size_type new_size = _round_to_pow2( count );
+        size_type new_cap  = 2 * new_size;
+
+        _vallocate( new_cap );
+        _construct_at_end( new_size );
+        _construct_at_end( _first_, _last_, count );
+        _construct_at_end( new_size - count );
+        _rebuild_tree();
 }
 
 template< typename T, auto PB, typename Allocator >
 segment_tree< T, PB, Allocator >::segment_tree ( segment_tree const & _other_ )
         : _base( _alloc_traits::select_on_container_copy_construction( _other_._alloc() ) )
 {
-        // default
+        size_type new_cap  = _other_.capacity();
+
+        if( new_cap > 0 )
+        {
+                _vallocate( new_cap );
+
+                for( size_type i = 0; i < new_cap; ++i )
+                {
+                        _construct_one_at_end( _other_.begin_[ i ] );
+                }
+        }
 }
 
 template< typename T, auto PB, typename Allocator >
 segment_tree< T, PB, Allocator >::segment_tree ( segment_tree const & _other_, _identity< allocator_type > const & _alloc_ )
         : _base( _alloc_ )
 {
-        // same as above
+        size_type new_cap  = _other_.capacity();
+
+        if( new_cap > 0 )
+        {
+                _vallocate( new_cap );
+
+                for( size_type i = 0; i < new_cap; ++i )
+                {
+                        _construct_one_at_end( _other_.begin_[ i ] );
+                }
+        }
 }
 
 template< typename T, auto PB, typename Allocator >
@@ -968,7 +1203,11 @@ inline
 segment_tree< T, PB, Allocator >::segment_tree ( segment_tree && _other_ ) noexcept
         : _base( NPL_MOVE( _other_._alloc() ) )
 {
-        // default
+        this->begin_   = _other_.begin_  ;
+        this->end_     = _other_.end_    ;
+        this->end_cap_ = _other_.end_cap_;
+
+        _other_.begin_ = _other_.end_ = _other_.end_cap_ = nullptr;
 }
 
 template< typename T, auto PB, typename Allocator >
@@ -976,17 +1215,36 @@ inline
 segment_tree< T, PB, Allocator >::segment_tree ( segment_tree && _other_, _identity< allocator_type > const & _alloc_ )
         : _base( _alloc_ )
 {
-        // same as above
+        if( _alloc_ == _other_._alloc() )
+        {
+                this->begin_   = _other_.begin_  ;
+                this->end_     = _other_.end_    ;
+                this->end_cap_ = _other_.end_cap_;
+
+                _other_.begin_ = _other_.end_ = _other_.end_cap_ = nullptr;
+        }
+        else
+        {
+                using mit = std::move_iterator< iterator >;
+                assign( mit( _other_.begin() ), mit( _other_.end() ) );
+        }
 }
 
 template< typename T, auto PB, typename Allocator >
 inline
 segment_tree< T, PB, Allocator >::segment_tree ( std::initializer_list< value_type > _list_ )
 {
-        // power of two
-        // alloc double
-        // fill
-        // construct tree
+        if( _list_.size() > 0 )
+        {
+                auto new_size = _round_to_pow2( _list_.size() );
+                auto new_cap  = 2 * new_size;
+
+                _vallocate( new_cap );
+                _construct_at_end( new_size );
+                _construct_at_end( _list_.begin(), _list_.end(), _list_.size() );
+                _construct_at_end( new_size - _list_.size() );
+                _rebuild_tree();
+        }
 }
 
 template< typename T, auto PB, typename Allocator >
@@ -994,7 +1252,16 @@ inline
 segment_tree< T, PB, Allocator >::segment_tree ( std::initializer_list< value_type > _list_, allocator_type const & _alloc_ )
         : _base( _alloc_ )
 {
+        if( _list_.size() > 0 )
+        {
+                auto new_size = _round_to_pow2( _list_.size() );
+                auto new_cap  = 2 * new_size;
 
+                _vallocate( new_cap );
+                _construct_at_end( _list_.begin(), _list_.end(), _list_.size() );
+                _construct_at_end( new_size - _list_.size() );
+                _rebuild_tree();
+        }
 }
 
 template< typename T, auto PB, typename Allocator >
@@ -1003,7 +1270,10 @@ segment_tree< T, PB, Allocator > &
 segment_tree< T, PB, Allocator >::operator= ( segment_tree && _other_ )
         noexcept( ( noexcept_move_assign_container_v< Allocator, _alloc_traits > ) )
 {
-        // default
+        _move_assign( _other_, std::integral_constant< bool,
+                        _alloc_traits::propagate_on_container_move_assignment::value >() );
+
+        return *this;
 }
 
 template< typename T, auto PB, typename Allocator >
@@ -1011,7 +1281,15 @@ void
 segment_tree< T, PB, Allocator >::_move_assign ( segment_tree & _other_, std::false_type )
         noexcept( _alloc_traits::is_always_equal::value )
 {
-        // default
+        if( _base::_alloc() != _other_._alloc() )
+        {
+                using mit = std::move_iterator< iterator >;
+                assign( mit( _other_.begin() ), mit( _other_.end() ) );
+        }
+        else
+        {
+                _move_assign( _other_, std::true_type() );
+        }
 }
 
 template< typename T, auto PB, typename Allocator >
@@ -1019,7 +1297,14 @@ void
 segment_tree< T, PB, Allocator >::_move_assign ( segment_tree & _other_, std::true_type )
         noexcept( std::is_nothrow_move_assignable_v< allocator_type > )
 {
-        // default
+        _vdeallocate();
+        _base::_move_assign_alloc( _other_ );
+
+        this->begin_   = _other_.begin_  ;
+        this->end_     = _other_.end_    ;
+        this->end_cap_ = _other_.end_cap_;
+
+        _other_.begin_ = _other_.end_ = _other_.end_cap_ = nullptr;
 }
 
 template< typename T, auto PB, typename Allocator >
@@ -1027,7 +1312,12 @@ inline
 segment_tree< T, PB, Allocator > &
 segment_tree< T, PB, Allocator >::operator= ( segment_tree const & _other_ )
 {
-        // default
+        if( this != &_other_ )
+        {
+                _base::_copy_assign_alloc( _other_ );
+                assign( _other_.begin(), _other_.end() );
+        }
+        return *this;
 }
 
 template< typename T, auto PB, typename Allocator >
@@ -1044,7 +1334,42 @@ typename std::enable_if_t
 >
 segment_tree< T, PB, Allocator >::assign ( SegtreeIterator _first_, SegtreeIterator _last_ )
 {
-        // default
+        size_type count    = static_cast< size_type >( std::distance( _first_, _last_ ) );
+        size_type new_size = _round_to_pow2( count );
+        size_type new_cap  = 2 * new_size;
+
+        if( new_cap < capacity() )
+        {
+                SegtreeIterator mid = _last_;
+                bool growing = false;
+
+                if( new_size > real_size() )
+                {
+                        growing = true;
+                        mid = _first_;
+                        std::advance( mid, real_size() );
+                }
+
+                pointer mid_ptr = std::copy( _first_, mid, this->begin_ );
+
+                if( growing )
+                {
+                        _construct_at_end( mid, _last_, new_size - real_size() );
+                }
+                else
+                {
+                        this->_destruct_at_end( mid_ptr );
+                }
+        }
+        else
+        {
+                _vdeallocate();
+                _vallocate( new_cap );
+                _construct_at_end( new_size );
+                _construct_at_end( _first_, _last_, count );
+        }
+        _rebuild_tree();
+        _invalidate_all_iterators();
 }
 
 template< typename T, auto PB, typename Allocator >
@@ -1063,10 +1388,15 @@ typename std::enable_if_t
 >
 segment_tree< T, PB, Allocator >::assign ( InputIterator _first_, InputIterator _last_ )
 {
-        // emplace back
+        this->_destruct_at_end( this->begin_ + capacity() / 2 );
+
+        for( ; _first_ != _last_; ++_first_ )
+        {
+                _emplace_back( *_first_ );
+        }
+        _rebuild_tree();
 }
 
-#if 0
 template< typename T, auto PB, typename Allocator >
 template< typename ForwardIterator >
 typename std::enable_if_t
@@ -1082,9 +1412,29 @@ typename std::enable_if_t
 >
 segment_tree< T, PB, Allocator >::assign ( ForwardIterator _first_, ForwardIterator _last_ )
 {
+        size_type count    = std::distance( _first_, _last_ );
+        size_type new_size = _round_to_pow2( count );
+        size_type new_cap  = 2 * new_size;
 
+        if( new_cap > capacity() )
+        {
+                clear();
+                _vdeallocate();
+                _vallocate( new_cap );
+                _construct_at_end( new_size );
+                _construct_at_end( _first_, _last_, count );
+                _construct_at_end( new_size - count );
+                _rebuild_tree();
+        }
+        else
+        {
+                this->_destruct_at_end( this->begin_ + capacity() / 2 );
+
+                _construct_at_end( _first_, _last_, count );
+                _construct_at_end( new_size - count );
+                _rebuild_tree();
+        }
 }
-#endif
 
 template< typename T, auto PB, typename Allocator >
 inline
@@ -1107,7 +1457,7 @@ inline
 typename segment_tree< T, PB, Allocator >::iterator
 segment_tree< T, PB, Allocator >::begin () noexcept
 {
-        return _make_iter( this->begin_ );
+        return _make_iter( this->begin_ + capacity() / 2 );
 }
 
 template< typename T, auto PB, typename Allocator >
@@ -1115,7 +1465,7 @@ inline
 typename segment_tree< T, PB, Allocator >::const_iterator
 segment_tree< T, PB, Allocator >::begin () const noexcept
 {
-        return _make_iter( this->begin_ );
+        return _make_iter( this->begin_ + capacity() / 2 );
 }
 
 template< typename T, auto PB, typename Allocator >
@@ -1139,7 +1489,9 @@ NPL_ALWAYS_INLINE
 typename segment_tree< T, PB, Allocator >::reference
 segment_tree< T, PB, Allocator >::operator[] ( size_type const _index_ ) noexcept
 {
-        // return being + size / 2 + index
+        NPL_ASSERT( !empty() && _index_ < size(), "segment_tree::operator[]: index out of bounds" );
+
+        return this->begin_[ capacity() / 2 + _index_ ];
 }
 
 template< typename T, auto PB, typename Allocator >
@@ -1147,7 +1499,9 @@ NPL_ALWAYS_INLINE
 typename segment_tree< T, PB, Allocator >::const_reference
 segment_tree< T, PB, Allocator >::operator[] ( size_type const _index_ ) const noexcept
 {
-        // same as above
+        NPL_ASSERT( !empty() && _index_ < size(), "segment_tree::operator[]: index out of bounds" );
+
+        return this->begin_[ capacity() / 2 + _index_ ];
 }
 
 template< typename T, auto PB, typename Allocator >
@@ -1155,7 +1509,25 @@ inline
 bool
 segment_tree< T, PB, Allocator >::operator== ( segment_tree const & _other_ ) const noexcept
 {
+        if( empty() && _other_.empty() )
+        {
+                return true;
+        }
 
+        if( size() != _other_.size() )
+        {
+                return false;
+        }
+
+        for( size_type i = 0; i < size(); ++i )
+        {
+                if( at( i ) != _other_.at( i ) )
+                {
+                        return false;
+                }
+        }
+
+        return true;
 }
 
 template< typename T, auto PB, typename Allocator >
@@ -1203,7 +1575,9 @@ NPL_ALWAYS_INLINE
 typename segment_tree< T, PB, Allocator >::reference
 segment_tree< T, PB, Allocator >::at ( size_type const _index_ ) noexcept
 {
-        // same as operator[]
+        NPL_ASSERT( !empty() && _index_ < size(), "segment_tree::at: index out of bounds" );
+
+        return this->begin_[ capacity() / 2 + _index_ ];
 }
 
 template< typename T, auto PB, typename Allocator >
@@ -1211,7 +1585,9 @@ NPL_ALWAYS_INLINE
 typename segment_tree< T, PB, Allocator >::const_reference
 segment_tree< T, PB, Allocator >::at ( size_type const _index_ ) const noexcept
 {
-        // same as above
+        NPL_ASSERT( !empty() && _index_ < size(), "segment_tree::at: index out of bounds" );
+
+        return this->begin_[ capacity() / 2 + _index_ ];
 }
 
 template< typename T, auto PB, typename Allocator >
@@ -1219,7 +1595,9 @@ NPL_ALWAYS_INLINE
 typename segment_tree< T, PB, Allocator >::value_type
 segment_tree< T, PB, Allocator >::element_at ( size_type const _index_ ) const noexcept
 {
+        NPL_ASSERT( !empty() && _index_ < capacity(), "segment_tree::element_at: index out of bounds" );
 
+        return this->begin_[ _index_ ];
 }
 
 template< typename T, auto PB, typename Allocator >
@@ -1227,15 +1605,38 @@ NPL_ALWAYS_INLINE NPL_FLATTEN
 typename segment_tree< T, PB, Allocator >::value_type
 segment_tree< T, PB, Allocator >::range () const noexcept
 {
+        NPL_ASSERT( !empty(), "segment_tree::range: called on empty segment tree" );
 
+        return range( 0, size() - 1 );
 }
 
 template< typename T, auto PB, typename Allocator >
 NPL_ALWAYS_INLINE
 typename segment_tree< T, PB, Allocator >::value_type
-segment_tree< T, PB, Allocator >::range ( size_type const _x_, size_type const _y_ ) const noexcept
+segment_tree< T, PB, Allocator >::range ( size_type _x_, size_type _y_ ) const noexcept
 {
+        NPL_ASSERT( !empty() && _x_ <= _y_ && _y_ < size(), "segment_tree::range: index out of bounds" );
 
+        _x_ += capacity() / 2;
+        _y_ += capacity() / 2;
+
+        T res = T();
+
+        while( _x_ <= _y_ )
+        {
+                if( _x_ % 2 == 1 )
+                {
+                        res = parent_builder_( res, this->begin_[ _x_++ ] );
+                }
+                if( _y_ % 2 == 0 )
+                {
+                        res = parent_builder_( res, this->begin_[ _y_-- ] );
+                }
+                _x_ /= 2;
+                _y_ /= 2;
+        }
+
+        return res;
 }
 
 template< typename T, auto PB, typename Allocator >
@@ -1290,7 +1691,16 @@ inline
 typename segment_tree< T, PB, Allocator >::reference
 segment_tree< T, PB, Allocator >::emplace_back ( Args&&... _args_ )
 {
+        if( this->end_ != this->end_cap_ )
+        {
+                _update( size(), NPL_FWD( _args_ )... );
+        }
+        else
+        {
 
+        }
+
+        return this->back();
 }
 
 template< typename T, auto PB, typename Allocator >
@@ -1319,7 +1729,18 @@ template< typename T, auto PB, typename Allocator >
 void
 segment_tree< T, PB, Allocator >::swap ( segment_tree & _other_ ) noexcept
 {
+        NPL_ASSERT( _alloc_traits::propagate_on_container_swap::value || this->_alloc() == _other_._alloc(),
+                        "segment_tree::swap: if lhs.alloc != rhs.alloc, alloc_type needs to propagate on swap" );
 
+        std::swap( this->begin_  , _other_.begin_   );
+        std::swap( this->end_    , _other_.end_     );
+        std::swap( this->end_cap_, _other_.end_cap_ );
+
+        mem::_swap_allocator( this->_alloc(), _other_._alloc(),
+                        std::integral_constant< bool, _alloc_traits::propagate_on_container_swap::value >() );
+
+        _rebuild_tree();
+        _other_._rebuild_tree();
 }
 
 template< typename T, auto PB, typename Allocator >
@@ -1338,7 +1759,29 @@ template< typename T, auto PB, typename Allocator >
 bool
 segment_tree< T, PB, Allocator >::_invariants () const noexcept
 {
-
+        if( this->begin_ == nullptr )
+        {
+                if( this->end_ != nullptr || this->end_cap_ != nullptr )
+                {
+                        return false;
+                }
+        }
+        else
+        {
+                if( this->begin_ > this->end_ )
+                {
+                        return false;
+                }
+                if( this->begin_ == this->end_cap_ )
+                {
+                        return false;
+                }
+                if( this->end_ > this->end_cap_ )
+                {
+                        return false;
+                }
+        }
+        return true;
 }
 
 template< typename T, auto PB, typename Allocator >

--- a/include/util/traits.hpp
+++ b/include/util/traits.hpp
@@ -68,11 +68,13 @@ inline constexpr bool is_default_allocator_v = is_default_allocator< T >::value;
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 template< typename Alloc, typename... Args,
           typename = decltype( std::declval< Alloc >().construct( std::declval< Args >()... ) ) >
 static std::true_type test_has_construct( int );
 template< typename Alloc, typename... >
 static std::false_type test_has_construct( ... );
+
 #pragma GCC diagnostic pop
 
 template< typename Alloc, typename... Args >

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(
         gtest_vector.cpp
         gtest_prefix.cpp
         gtest_fenwick.cpp
+        gtest_segtree.cpp
 )
 target_link_libraries(
         gtest_nplib
@@ -25,6 +26,13 @@ target_include_directories(
         PUBLIC
         ${CMAKE_HOME_DIRECTORY}/include
 )
+
+add_compile_options( -O1 )
+add_compile_definitions( NPL_DEBUG )
+
+if( NPL_HAS_ASAN )
+        add_compile_definitions( NPL_HAS_ASAN )
+endif()
 
 include( GoogleTest )
 gtest_discover_tests( gtest_nplib )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,11 +9,12 @@ FetchContent_MakeAvailable( googletest )
 
 enable_testing()
 
-file( GLOB_RECURSE sources ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
-
 add_executable(
         gtest_nplib
-        ${sources}
+        gtest_nplib.cpp
+        gtest_vector.cpp
+        gtest_prefix.cpp
+        gtest_fenwick.cpp
 )
 target_link_libraries(
         gtest_nplib

--- a/tests/gtest_nplib.hpp
+++ b/tests/gtest_nplib.hpp
@@ -24,6 +24,7 @@
 
 #include <range_queries/prefix_array>
 #include <range_queries/fenwick_tree>
+#include <range_queries/segment_tree>
 
 #define CUSTOM_CAPACITY 8
 #define CUSTOM_VALUE    1

--- a/tests/gtest_segtree.cpp
+++ b/tests/gtest_segtree.cpp
@@ -267,10 +267,12 @@ TEST( SegtreeTest, Range )
         }
 }
 
+/*
 TEST( SegtreeTest, ParentBuilders )
 {
         EXPECT_EQ( true, false );
 }
+*/
 
 TEST( SegtreeTest, Accessors )
 {

--- a/tests/gtest_segtree.cpp
+++ b/tests/gtest_segtree.cpp
@@ -1,0 +1,472 @@
+//
+//
+//      natprolib
+//      gtest_segtree.cpp
+//
+
+#include "gtest_segtree.hpp"
+
+
+TEST( SegtreeTest, DefaultConstruct )
+{
+        npl::segment_tree<      int >    int_seg;
+        npl::segment_tree< unsigned >   uint_seg;
+        npl::segment_tree<    float >  float_seg;
+        npl::segment_tree<   double > double_seg;
+
+        EXPECT_EQ(    int_seg._invariants(), true );
+        EXPECT_EQ(   uint_seg._invariants(), true );
+        EXPECT_EQ(  float_seg._invariants(), true );
+        EXPECT_EQ( double_seg._invariants(), true );
+}
+
+TEST( SegtreeTest, ReserveConstruct )
+{
+        npl::segment_tree< int > seg( CUSTOM_CAPACITY );
+
+        EXPECT_EQ( seg._invariants(),                true );
+        EXPECT_EQ( seg.size()       ,                   8 );
+        EXPECT_EQ( seg.capacity()   , 2 * CUSTOM_CAPACITY );
+}
+
+TEST( SegtreeTest, FillConstruct )
+{
+        npl::segment_tree< int > seg( CUSTOM_CAPACITY, CUSTOM_VALUE );
+
+        EXPECT_EQ( seg._invariants(),            true );
+        EXPECT_EQ( seg.size()       , CUSTOM_CAPACITY );
+}
+
+TEST( SegtreeTest, SegtreeIterConstruct )
+{
+        npl::segment_tree< int > seg1( CUSTOM_CAPACITY, CUSTOM_VALUE );
+
+        EXPECT_EQ( seg1._invariants(),            true );
+        EXPECT_EQ( seg1.size()       , CUSTOM_CAPACITY );
+
+        npl::segment_tree< int > seg2( seg1.begin(), seg1.end() );
+
+        EXPECT_EQ( seg1._invariants(),            true );
+        EXPECT_EQ( seg1.size()       , CUSTOM_CAPACITY );
+}
+
+/*
+TEST( SegtreeTest, InputIterConstruct )
+{
+        std::vector< int > source( CUSTOM_CAPACITY, CUSTOM_VALUE );
+
+        using input_iter = nplib_test::input_iterator< int, true, decltype( source.get_allocator() ) >;
+
+        input_iter begin( &source[ 0 ] );
+        input_iter end  ( &source[ source.size() - 1 ] + 1 );
+
+        npl::segment_tree< int > seg( begin, end );
+
+        EXPECT_EQ( seg._invariants(),            true );
+        EXPECT_EQ( seg.size()       , CUSTOM_CAPACITY );
+}
+*/
+
+TEST( SegtreeTest, ForwardIterConstruct )
+{
+        std::vector< int > source( CUSTOM_CAPACITY, CUSTOM_VALUE );
+
+        npl::segment_tree< int > seg( source.begin(), source.end() );
+
+        EXPECT_EQ( seg._invariants(),            true );
+        EXPECT_EQ( seg.size()       , CUSTOM_CAPACITY );
+}
+
+TEST( SegtreeTest, CopyConstruct )
+{
+        npl::segment_tree< int > source( CUSTOM_CAPACITY, CUSTOM_VALUE );
+
+        EXPECT_EQ( source._invariants(),            true );
+        EXPECT_EQ( source.size()       , CUSTOM_CAPACITY );
+
+        npl::segment_tree< int > seg( source );
+
+        EXPECT_EQ( seg._invariants(),            true );
+        EXPECT_EQ( seg.size()       , CUSTOM_CAPACITY );
+        EXPECT_EQ( seg              ,          source );
+}
+
+TEST( SegtreeTest, MoveConstruct )
+{
+        npl::segment_tree< int > source( CUSTOM_CAPACITY, CUSTOM_VALUE );
+
+        EXPECT_EQ( source._invariants(),            true );
+        EXPECT_EQ( source.size()       , CUSTOM_CAPACITY );
+
+        npl::segment_tree< int > seg( NPL_MOVE( source ) );
+
+        EXPECT_EQ( source._invariants(),            true );
+        EXPECT_EQ( source.empty()      ,            true );
+
+        EXPECT_EQ( seg._invariants(),            true );
+        EXPECT_EQ( seg.size()       , CUSTOM_CAPACITY );
+}
+
+TEST( SegtreeTest, InitListConstruct )
+{
+        npl::segment_tree< int > seg( { 1, 1, 1, 1, 1, 1, 1, 1 } );
+
+        EXPECT_EQ( seg._invariants(), true );
+        EXPECT_EQ( seg.size()       ,    8 );
+}
+
+TEST( SegtreeTest, CopyAssign )
+{
+        npl::segment_tree< int > source( CUSTOM_CAPACITY, CUSTOM_VALUE );
+        npl::segment_tree< int > seg;
+
+        EXPECT_EQ( source._invariants(),            true );
+        EXPECT_EQ( source.size()       , CUSTOM_CAPACITY );
+
+        seg = source;
+
+        EXPECT_EQ( seg._invariants(),            true );
+        EXPECT_EQ( seg.size()       , CUSTOM_CAPACITY );
+        EXPECT_EQ( seg              ,          source );
+}
+
+TEST( SegtreeTest, MoveAssign )
+{
+        npl::segment_tree< int > source( CUSTOM_CAPACITY, CUSTOM_VALUE );
+        npl::segment_tree< int > seg;
+
+        EXPECT_EQ( source._invariants(),            true );
+        EXPECT_EQ( source.size()       , CUSTOM_CAPACITY );
+
+        seg = NPL_MOVE( source );
+
+        EXPECT_EQ( source._invariants(),            true );
+        EXPECT_EQ( source.empty()      ,            true );
+
+        EXPECT_EQ( seg._invariants(),            true );
+        EXPECT_EQ( seg.size()       , CUSTOM_CAPACITY );
+}
+
+TEST( SegtreeTest, InitListAssign )
+{
+        npl::segment_tree< int > seg;
+
+        EXPECT_EQ( seg._invariants(), true );
+        EXPECT_EQ( seg.size()       ,    0 );
+
+        seg = { 1, 1, 1, 1, 1, 1, 1, 1 };
+
+        EXPECT_EQ( seg._invariants(), true );
+        EXPECT_EQ( seg.size()       ,    8 );
+}
+
+/*
+TEST( SegtreeTest, Assign ) // add to other containers as well, tests all assign(...)s
+{
+
+}
+*/
+
+TEST( SegtreeTest, SubscriptOperator )
+{
+        std::vector< int > seg( CUSTOM_CAPACITY, CUSTOM_VALUE );
+
+        npl::segment_tree< int > vec_fill ( CUSTOM_CAPACITY, CUSTOM_VALUE );
+        npl::segment_tree< int > vec_piter( vec_fill.begin(), vec_fill.end() );
+        npl::segment_tree< int > vec_fiter( seg.begin(), seg.end() );
+        npl::segment_tree< int > vec_copy ( vec_fill );
+        npl::segment_tree< int > vec_init ( { 1, 1, 1, 1, 1, 1, 1, 1 } );
+
+        npl::segment_tree< int > vec_cpass;
+        vec_cpass = vec_fill;
+
+        for( std::size_t i = 0; i < CUSTOM_CAPACITY; ++i )
+        {
+                EXPECT_EQ( vec_fill [ i ], 1 );
+                EXPECT_EQ( vec_piter[ i ], 1 );
+                EXPECT_EQ( vec_fiter[ i ], 1 );
+                EXPECT_EQ( vec_copy [ i ], 1 );
+                EXPECT_EQ( vec_init [ i ], 1 );
+                EXPECT_EQ( vec_cpass[ i ], 1 );
+        }
+}
+
+TEST( SegtreeTest, At )
+{
+        std::vector< int > seg( CUSTOM_CAPACITY, CUSTOM_VALUE );
+
+        npl::segment_tree< int > vec_fill ( CUSTOM_CAPACITY, CUSTOM_VALUE );
+        npl::segment_tree< int > vec_piter( vec_fill.begin(), vec_fill.end() );
+        npl::segment_tree< int > vec_fiter( seg.begin(), seg.end() );
+        npl::segment_tree< int > vec_copy ( vec_fill );
+        npl::segment_tree< int > vec_init ( { 1, 1, 1, 1, 1, 1, 1, 1 } );
+
+        npl::segment_tree< int > vec_cpass;
+        vec_cpass = vec_fill;
+
+        for( std::size_t i = 0; i < CUSTOM_CAPACITY; ++i )
+        {
+                EXPECT_EQ( vec_fill .at( i ), 1 );
+                EXPECT_EQ( vec_piter.at( i ), 1 );
+                EXPECT_EQ( vec_fiter.at( i ), 1 );
+                EXPECT_EQ( vec_copy .at( i ), 1 );
+                EXPECT_EQ( vec_init .at( i ), 1 );
+                EXPECT_EQ( vec_cpass.at( i ), 1 );
+        }
+}
+
+TEST( SegtreeTest, ElementAt )
+{
+        std::vector< int > seg( CUSTOM_CAPACITY, CUSTOM_VALUE );
+
+        npl::segment_tree< int > vec_fill ( CUSTOM_CAPACITY, CUSTOM_VALUE );
+        npl::segment_tree< int > vec_piter( vec_fill.begin(), vec_fill.end() );
+        npl::segment_tree< int > vec_fiter( seg.begin(), seg.end() );
+        npl::segment_tree< int > vec_copy ( vec_fill );
+        npl::segment_tree< int > vec_init ( { 1, 1, 1, 1, 1, 1, 1, 1 } );
+
+        npl::segment_tree< int > vec_cpass;
+        vec_cpass = vec_fill;
+
+        for( std::size_t i = 0; i < CUSTOM_CAPACITY; ++i )
+        {
+                EXPECT_EQ( vec_fill .element_at( i + CUSTOM_CAPACITY ), 1 );
+                EXPECT_EQ( vec_piter.element_at( i + CUSTOM_CAPACITY ), 1 );
+                EXPECT_EQ( vec_fiter.element_at( i + CUSTOM_CAPACITY ), 1 );
+                EXPECT_EQ( vec_copy .element_at( i + CUSTOM_CAPACITY ), 1 );
+                EXPECT_EQ( vec_init .element_at( i + CUSTOM_CAPACITY ), 1 );
+                EXPECT_EQ( vec_cpass.element_at( i + CUSTOM_CAPACITY ), 1 );
+        }
+
+}
+
+TEST( SegtreeTest, Range )
+{
+        std::vector< int > vec( CUSTOM_CAPACITY, CUSTOM_VALUE );
+
+        npl::segment_tree< int, pb_sum< int > > segtree_fill ( CUSTOM_CAPACITY, CUSTOM_VALUE );
+        npl::segment_tree< int, pb_sum< int > > segtree_piter( segtree_fill.begin(), segtree_fill.end() );
+        npl::segment_tree< int, pb_sum< int > > segtree_fiter( vec.begin(), vec.end() );
+        npl::segment_tree< int, pb_sum< int > > segtree_copy ( segtree_fill );
+        npl::segment_tree< int, pb_sum< int > > segtree_init ( { 1, 1, 1, 1, 1, 1, 1, 1 } );
+
+        npl::segment_tree< int, pb_sum< int > > segtree_cpass;
+        segtree_cpass = segtree_fill;
+
+        for( std::size_t i = 0; i < CUSTOM_CAPACITY; ++i )
+        {
+                for( std::size_t j = i; j < CUSTOM_CAPACITY; ++j )
+                {
+                        EXPECT_EQ( segtree_fill .range( i, j ), j - i + 1 );
+                        EXPECT_EQ( segtree_piter.range( i, j ), j - i + 1 );
+                        EXPECT_EQ( segtree_fiter.range( i, j ), j - i + 1 );
+                        EXPECT_EQ( segtree_copy .range( i, j ), j - i + 1 );
+                        EXPECT_EQ( segtree_init .range( i, j ), j - i + 1 );
+                        EXPECT_EQ( segtree_cpass.range( i, j ), j - i + 1 );
+                }
+        }
+}
+
+TEST( SegtreeTest, ParentBuilders )
+{
+        EXPECT_EQ( true, false );
+}
+
+TEST( SegtreeTest, Accessors )
+{
+        npl::segment_tree< int > seg( CUSTOM_CAPACITY, CUSTOM_VALUE );
+
+        EXPECT_EQ( *seg.begin()  , 1 );
+        EXPECT_EQ( *seg.cbegin() , 1 );
+        EXPECT_EQ( *seg.rbegin() , 1 );
+        EXPECT_EQ( *seg.crbegin(), 1 );
+
+        EXPECT_EQ( *( --seg.end()   ), 1 );
+        EXPECT_EQ( *( --seg.cend()  ), 1 );
+        EXPECT_EQ( *( --seg.rend()  ), 1 );
+        EXPECT_EQ( *( --seg.crend() ), 1 );
+
+        EXPECT_EQ( seg.front() , 1 );
+        EXPECT_EQ( seg.cfront(), 1 );
+        EXPECT_EQ( seg.back()  , 1 );
+        EXPECT_EQ( seg.cback() , 1 );
+
+        EXPECT_EQ( *( seg.data() )                     , 0 );
+        EXPECT_EQ( *( seg.data() + seg.capacity() - 1 ), 1 );
+}
+
+/*
+TEST( SegtreeTest, PushBack )
+{
+        std::vector< int > seg( CUSTOM_CAPACITY, CUSTOM_VALUE );
+
+        npl::segment_tree< int > vec_def;
+        npl::segment_tree< int > vec_fill ( CUSTOM_CAPACITY, CUSTOM_VALUE );
+        npl::segment_tree< int > vec_piter( seg.begin(), seg.end() );
+        npl::segment_tree< int > vec_fiter( seg.begin(), seg.end() );
+        npl::segment_tree< int > vec_copy ( vec_fill );
+        npl::segment_tree< int > vec_init ( { 1, 1, 1, 1, 1, 1, 1, 1 } );
+
+        npl::segment_tree< int > vec_cpass;
+        vec_cpass = vec_fill;
+
+        for( std::size_t i = 0; i < 1024; ++i )
+        {
+                vec_def  .push_back( 1 );
+                vec_fill .push_back( 1 );
+                vec_piter.push_back( 1 );
+                vec_fiter.push_back( 1 );
+                vec_copy .push_back( 1 );
+                vec_init .push_back( 1 );
+                vec_cpass.push_back( 1 );
+
+                EXPECT_EQ( vec_def  .size(), i + 1 );
+                EXPECT_EQ( vec_fill .size(), CUSTOM_CAPACITY + i + 1 );
+                EXPECT_EQ( vec_piter.size(), CUSTOM_CAPACITY + i + 1 );
+                EXPECT_EQ( vec_fiter.size(), CUSTOM_CAPACITY + i + 1 );
+                EXPECT_EQ( vec_copy .size(), CUSTOM_CAPACITY + i + 1 );
+                EXPECT_EQ( vec_init .size(), CUSTOM_CAPACITY + i + 1 );
+                EXPECT_EQ( vec_cpass.size(), CUSTOM_CAPACITY + i + 1 );
+        }
+}
+
+TEST( SegtreeTest, EmplaceBackBasic )
+{
+        std::vector< int > seg( CUSTOM_CAPACITY, CUSTOM_VALUE );
+
+        npl::segment_tree< int > vec_def;
+        npl::segment_tree< int > vec_fill ( CUSTOM_CAPACITY, CUSTOM_VALUE );
+        npl::segment_tree< int > vec_piter( vec_fill.begin(), vec_fill.end() );
+        npl::segment_tree< int > vec_fiter( seg.begin(), seg.end() );
+        npl::segment_tree< int > vec_copy ( vec_fill );
+        npl::segment_tree< int > vec_init ( { 1, 1, 1, 1, 1, 1, 1, 1 } );
+
+        npl::segment_tree< int > vec_cpass;
+        vec_cpass = vec_fill;
+
+        for( std::size_t i = 0; i < 1024; ++i )
+        {
+                vec_def  .emplace_back( 1 );
+                vec_fill .emplace_back( 1 );
+                vec_piter.emplace_back( 1 );
+                vec_fiter.emplace_back( 1 );
+                vec_copy .emplace_back( 1 );
+                vec_init .emplace_back( 1 );
+                vec_cpass.emplace_back( 1 );
+
+                EXPECT_EQ( vec_def  .size(), i + 1 );
+                EXPECT_EQ( vec_fill .size(), CUSTOM_CAPACITY + i + 1 );
+                EXPECT_EQ( vec_piter.size(), CUSTOM_CAPACITY + i + 1 );
+                EXPECT_EQ( vec_fiter.size(), CUSTOM_CAPACITY + i + 1 );
+                EXPECT_EQ( vec_copy .size(), CUSTOM_CAPACITY + i + 1 );
+                EXPECT_EQ( vec_init .size(), CUSTOM_CAPACITY + i + 1 );
+                EXPECT_EQ( vec_cpass.size(), CUSTOM_CAPACITY + i + 1 );
+        }
+}
+
+TEST( SegtreeTest, EmplaceBack )
+{
+        std::vector< nplib_test::some_addable_data > seg( CUSTOM_CAPACITY, CUSTOM_VALUE );
+
+        npl::segment_tree< nplib_test::some_addable_data > vec_def;
+        npl::segment_tree< nplib_test::some_addable_data > vec_fill ( CUSTOM_CAPACITY, CUSTOM_VALUE );
+        npl::segment_tree< nplib_test::some_addable_data > vec_piter( vec_fill.begin(), vec_fill.end() );
+        npl::segment_tree< nplib_test::some_addable_data > vec_fiter( seg.begin(), seg.end() );
+        npl::segment_tree< nplib_test::some_addable_data > vec_copy ( vec_fill );
+        npl::segment_tree< nplib_test::some_addable_data > vec_init ( { 1, 1, 1, 1, 1, 1, 1, 1 } );
+
+        npl::segment_tree< nplib_test::some_addable_data > vec_cpass;
+        vec_cpass = vec_fill;
+
+        for( std::size_t i = 0; i < 1024; ++i )
+        {
+                vec_def  .emplace_back( 1 );
+                vec_fill .emplace_back( 1 );
+                vec_piter.emplace_back( 1 );
+                vec_fiter.emplace_back( 1 );
+                vec_copy .emplace_back( 1 );
+                vec_init .emplace_back( 1 );
+
+                EXPECT_EQ( vec_def  .size(), i + 1 );
+                EXPECT_EQ( vec_fill .size(), CUSTOM_CAPACITY + i + 1 );
+                EXPECT_EQ( vec_piter.size(), CUSTOM_CAPACITY + i + 1 );
+                EXPECT_EQ( vec_fiter.size(), CUSTOM_CAPACITY + i + 1 );
+                EXPECT_EQ( vec_copy .size(), CUSTOM_CAPACITY + i + 1 );
+                EXPECT_EQ( vec_init .size(), CUSTOM_CAPACITY + i + 1 );
+        }
+}
+*/
+
+TEST( SegtreeTest, Swap )
+{
+        npl::segment_tree< int > vec1( CUSTOM_CAPACITY, CUSTOM_VALUE     );
+        npl::segment_tree< int > vec2( CUSTOM_CAPACITY, CUSTOM_VALUE + 1 );
+
+        npl::segment_tree< int > copy1( vec1 );
+        npl::segment_tree< int > copy2( vec2 );
+
+        vec1.swap( vec2 );
+
+        EXPECT_EQ( vec1, copy2 );
+        EXPECT_EQ( vec2, copy1 );
+}
+
+TEST( SegtreeTest, Clear )
+{
+        npl::segment_tree< int > seg( CUSTOM_CAPACITY, CUSTOM_VALUE );
+        npl::segment_tree< int > empty;
+
+        seg.clear();
+
+        EXPECT_EQ( seg, empty );
+}
+
+TEST( SegtreeTest, TwoDimensional )
+{
+        npl::segment_tree< int > seg1d( CUSTOM_CAPACITY, CUSTOM_VALUE );
+
+        npl::segment_tree< npl::segment_tree< int > > seg2d( CUSTOM_CAPACITY, seg1d );
+
+        EXPECT_EQ( seg2d._invariants(),            true );
+        EXPECT_EQ( seg2d.size()       , CUSTOM_CAPACITY );
+
+        for( std::size_t i = 0; i < CUSTOM_CAPACITY; ++i )
+        {
+                EXPECT_EQ( seg2d.at( i ), seg1d );
+
+                for( std::size_t j = 0; j < seg2d.at( i ).size(); ++j )
+                {
+//                        EXPECT_EQ( seg2d.at( i, j ), seg1d.at( j ) );
+                        EXPECT_EQ( seg2d.at( i ).at( j ), seg1d.at( j ) );
+                }
+        }
+}
+
+TEST( SegtreeTest, ThreeDimensional )
+{
+        npl::segment_tree< int > seg1d( CUSTOM_CAPACITY, CUSTOM_VALUE );
+
+        npl::segment_tree seg2d( CUSTOM_CAPACITY, seg1d );
+        npl::segment_tree seg3d( CUSTOM_CAPACITY, seg2d );
+
+        EXPECT_EQ( seg3d._invariants(),            true );
+        EXPECT_EQ( seg3d.size()       , CUSTOM_CAPACITY );
+
+        for( std::size_t i = 0; i < CUSTOM_CAPACITY; ++i )
+        {
+                EXPECT_EQ( seg3d.at( i ), seg2d );
+
+                for( std::size_t j = 0; j < seg3d.at( i ).size(); ++j )
+                {
+//                        EXPECT_EQ( seg3d.at( i, j ), seg2d.at( j ) );
+                        EXPECT_EQ( seg3d.at( i ).at( j ), seg2d.at( j ) );
+
+//                        for( std::size_t k = 0; k < seg3d.at( i, j ).size(); ++k )
+                        for( std::size_t k = 0; k < seg3d.at( i ).at( j ).size(); ++k )
+                        {
+//                                EXPECT_EQ( seg3d.at( i, j, k ), seg2d.at( j, k ) );
+                                EXPECT_EQ( seg3d.at( i ).at( j ).at( k ), seg2d.at( j ).at( k ) );
+                        }
+                }
+        }
+}

--- a/tests/gtest_segtree.hpp
+++ b/tests/gtest_segtree.hpp
@@ -1,0 +1,37 @@
+//
+//
+//      natprolib
+//      gtest_segtree.hpp
+//
+
+#pragma once
+
+#include "gtest_nplib.hpp"
+
+
+template< typename T >
+auto pb_max
+{
+        []( T const & lhs, T const & rhs )
+        {
+                return lhs > rhs ? lhs : rhs;
+        }
+};
+
+template< typename T >
+auto pb_min
+{
+        []( T const & lhs, T const & rhs )
+        {
+                return lhs < rhs ? lhs : rhs;
+        }
+};
+
+template< typename T >
+auto pb_sum
+{
+        []( T const & lhs, T const & rhs )
+        {
+                return lhs + rhs;
+        }
+};


### PR DESCRIPTION
- lifted c++ standard requirement to c++20 to enable lambdas as parent builders for segment trees (build with c++17 still possible)